### PR TITLE
[wip] Strongly Typed Go SDK

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -24,13 +24,13 @@ func main() {
 }
 
 // MyMethod is a sample method to invoke
-func MyMethod(ctx context.Context, args proto.Message) (result proto.Message, err error) {
+func MyMethod(ctx context.Context, args proto.Message, meta map[string]string) (result proto.Message, err error) {
 	return &wrappers.StringValue{Value: `Hi there!`}, nil
 }
 
-func storage(ctx context.Context, args proto.Message) (result proto.Message, err error) {
+func storage(ctx context.Context, args proto.Message, meta map[string]string) (result proto.Message, options []dapr.Option, err error) {
 	fmt.Println("Invoked from binding")
-	return &empty.Empty{}, nil
+	return &empty.Empty{}, nil, nil
 }
 
 // TopicA is a sample topic handler

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -12,10 +12,6 @@ import (
 	"github.com/dapr/go-sdk/pkg/dapr"
 )
 
-// server is our user app
-type server struct {
-}
-
 func main() {
 	dapr.AddInvokeHandler(`MyMethod`, MyMethod)
 	dapr.AddBindingHandler(`storage`, storage)

--- a/pkg/dapr/dapr.go
+++ b/pkg/dapr/dapr.go
@@ -143,9 +143,15 @@ type Server interface {
 // TODO!!!! These methods are some helpers to get from any.Any to user defined proto.Message
 
 func toAny(in proto.Message) (*any.Any, error) {
-	return nil, errors.New(`TODO: toAny`)
+	data, err := proto.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	return &any.Any{
+		Value: data,
+	}, nil
 }
 
 func fromAny(obj proto.Message, stuff *any.Any) error {
-	return errors.New(`TODO: fromAny`)
+	return proto.Unmarshal(stuff.Value, obj)
 }

--- a/pkg/dapr/dapr.go
+++ b/pkg/dapr/dapr.go
@@ -1,0 +1,46 @@
+package dapr
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// NewClient ... TODO
+func NewClient(opts ...interface{}) (Client, error) {
+	// TODO: dial the connection and create a NewDaprClient (or accept a conn)
+	return nil, nil
+}
+
+// Client ... TODO
+type Client interface {
+	Invoke(ctx context.Context, service, method string, arguments, result proto.Message) error
+	Publish(ctx context.Context, topic string, data proto.Message) error
+	Binding(ctx context.Context, name string, data proto.Message) error
+
+	// State Methods
+	SaveState(ctx context.Context, requests ...*State) error
+	GetState(ctx context.Context, key string) (*State, error)
+	DeleteState(ctx context.Context, key string) (*State, error)
+}
+
+// State ... TODO
+type State struct {
+	Name  string
+	Value proto.Message
+}
+
+// Register ... TODO
+func Register(server Server) error {
+	// TODO: do a server registration
+	return nil
+}
+
+// Server ... TODO
+type Server interface {
+	Subscriptions() []string
+	Bindings() []string
+	OnBinding(ctx context.Context, args interface{}) (interface{}, error) // TODO: stronger types
+	OnTopic(ctx context.Context, msg proto.Message) error
+	// TODO: use reflection to call additional methods when getting OnInvoke messages
+}

--- a/pkg/dapr/dapr.go
+++ b/pkg/dapr/dapr.go
@@ -2,38 +2,133 @@ package dapr
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/grpc"
+
+	"github.com/dapr/go-sdk/dapr"
 )
 
 // NewClient ... TODO
-func NewClient(opts ...interface{}) (Client, error) {
-	// TODO: dial the connection and create a NewDaprClient (or accept a conn)
-	return nil, nil
+func NewClient(opts ...grpc.DialOption) (*Client, error) {
+	daprPort := os.Getenv("DAPR_GRPC_PORT")
+	daprAddress := fmt.Sprintf("localhost:%s", daprPort)
+	conn, err := grpc.Dial(daprAddress, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		client: dapr.NewDaprClient(conn),
+		conn:   conn,
+	}, nil
 }
 
 // Client ... TODO
-type Client interface {
-	Invoke(ctx context.Context, service, method string, arguments, result proto.Message) error
-	Publish(ctx context.Context, topic string, data proto.Message) error
-	Binding(ctx context.Context, name string, data proto.Message) error
+type Client struct {
+	client dapr.DaprClient
+	conn   io.Closer
+}
 
-	// State Methods
-	SaveState(ctx context.Context, requests ...*State) error
-	GetState(ctx context.Context, key string) (*State, error)
-	DeleteState(ctx context.Context, key string) (*State, error)
+// Invoke ... TODO
+func (c *Client) Invoke(ctx context.Context, service, method string, arguments, result proto.Message) error {
+	args, err := toAny(arguments)
+	if err != nil {
+		return nil
+	}
+	res, err := c.client.InvokeService(ctx, &dapr.InvokeServiceEnvelope{
+		Id:     service,
+		Method: method,
+		Data:   args,
+	})
+	if err != nil {
+		return err
+	}
+	return fromAny(result, res.Data)
+}
+
+// Publish ... TODO
+func (c *Client) Publish(ctx context.Context, topic string, data proto.Message) error {
+	d, err := toAny(data)
+	if err != nil {
+		return err
+	}
+	_, err = c.client.PublishEvent(context.Background(), &dapr.PublishEventEnvelope{
+		Topic: topic,
+		Data:  d,
+	})
+	return err
+}
+
+// Binding ... TODO
+func (c *Client) Binding(ctx context.Context, name string, data proto.Message) error {
+	d, err := toAny(data)
+	if err != nil {
+		return err
+	}
+	_, err = c.client.InvokeBinding(context.Background(), &dapr.InvokeBindingEnvelope{
+		Name: name,
+		Data: d,
+	})
+	return err
+}
+
+// SaveState ... TODO
+func (c *Client) SaveState(ctx context.Context, requests ...*State) error {
+	reqs := make([]*dapr.StateRequest, len(requests))
+	for i, request := range requests {
+		req, err := toAny(request.Value)
+		if err != nil {
+			return err
+		}
+		reqs[i] = &dapr.StateRequest{
+			Key:   request.Key,
+			Value: req,
+		}
+	}
+	_, err := c.client.SaveState(ctx, &dapr.SaveStateEnvelope{Requests: reqs})
+	return err
+}
+
+// GetState ... TODO
+func (c *Client) GetState(ctx context.Context, key string, result proto.Message) error {
+	r, err := c.client.GetState(ctx, &dapr.GetStateEnvelope{
+		Key: key,
+	})
+	if err != nil {
+		return err
+	}
+	return fromAny(result, r.Data)
+}
+
+// DeleteState ... TODO
+func (c *Client) DeleteState(ctx context.Context, key string) error {
+	_, err := c.client.DeleteState(ctx, &dapr.DeleteStateEnvelope{
+		Key: key,
+	})
+	return err
+}
+
+// Close ... TODO
+func (c *Client) Close() error {
+	return c.conn.Close()
 }
 
 // State ... TODO
 type State struct {
-	Name  string
+	Key   string
 	Value proto.Message
 }
 
-// Register ... TODO
-func Register(server Server) error {
-	// TODO: do a server registration
-	return nil
+// Serve ... TODO
+func Serve(port int, server Server) error {
+	// TODO: read port as env var DAPR_PORT
+	// https://github.com/dapr/dapr/issues/102
+	return errors.New(`TODO`)
 }
 
 // Server ... TODO
@@ -43,4 +138,14 @@ type Server interface {
 	OnBinding(ctx context.Context, args interface{}) (interface{}, error) // TODO: stronger types
 	OnTopic(ctx context.Context, msg proto.Message) error
 	// TODO: use reflection to call additional methods when getting OnInvoke messages
+}
+
+// TODO!!!! These methods are some helpers to get from any.Any to user defined proto.Message
+
+func toAny(in proto.Message) (*any.Any, error) {
+	return nil, errors.New(`TODO: toAny`)
+}
+
+func fromAny(obj proto.Message, stuff *any.Any) error {
+	return errors.New(`TODO: fromAny`)
 }

--- a/pkg/dapr/options.go
+++ b/pkg/dapr/options.go
@@ -1,0 +1,44 @@
+package dapr
+
+import (
+	"errors"
+
+	"github.com/dapr/go-sdk/dapr"
+	"google.golang.org/grpc"
+)
+
+// Option is a functional form of an optional parameter.
+// https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
+type Option func(interface{}, []grpc.CallOption) ([]grpc.CallOption, error)
+
+// Metadata builds an option to add additionall metadata to the outgoing request.
+// TODO: use more specific, strongly typed APIs as the metadata gets better described.
+func Metadata(meta map[string]string) Option {
+	return func(obj interface{}, list []grpc.CallOption) ([]grpc.CallOption, error) {
+		switch t := obj.(type) {
+		case *dapr.InvokeServiceEnvelope:
+			t.Metadata = meta
+		case *dapr.InvokeBindingEnvelope:
+			t.Metadata = meta
+		default:
+			return list, errors.New(`dapr: invalid option`)
+		}
+		return list, nil
+	}
+}
+
+// CallOption allows direct control of the underlying GRPC call.
+func CallOption(opt grpc.CallOption) Option {
+	return func(obj interface{}, list []grpc.CallOption) ([]grpc.CallOption, error) {
+		return append(list, opt), nil
+	}
+}
+
+func applyOptions(req interface{}, opts []Option) (options []grpc.CallOption, err error) {
+	for _, opt := range opts {
+		if options, err = opt(req, options); err != nil {
+			return nil, err
+		}
+	}
+	return options, nil
+}


### PR DESCRIPTION
# Description

> One thing I noticed while looking through these SDKs is that they seem to just be exposing the generated gRPC code of the desired language. I was wondering if it's worth wrapping the gRPC logic in some thin, language specific wrappers. This could allow language specific patterns to be exposed in each of the SDKs rather than expecting all consumers to understand gRPC right out of the gate.
> \- https://github.com/dapr/go-sdk/issues/7

_TODO: better PR description (NOTE: PR is in draft state)_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/go-sdk/issues/7

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
