### PR TITLE
non-integer etag value in example

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -32,7 +32,7 @@ func main() {
 	logger.Println("data published")
 
 	// save state with the key key1
-	err = client.SaveStateData(ctx, "statestore", "key1", "v1", data)
+	err = client.SaveStateData(ctx, "statestore", "key1", "1", data)
 	if err != nil {
 		logger.Panic(err)
 	}


### PR DESCRIPTION
Better etag default to avoid error related to errors from Dapr HTTP API on a non-integer value (https://github.com/dapr/dapr/issues/1869)