### PR TITLE
HTTP serving implementation addressing #26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ test: mod ## Tests the entire project
 
 cover: mod ## Displays test coverage in the client and service packages
 	go test -coverprofile=cover-client.out ./client && go tool cover -html=cover-client.out
-	go test -coverprofile=cover-service.out ./service/grpc && go tool cover -html=cover-service.out
+	go test -coverprofile=cover-grpc.out ./service/grpc && go tool cover -html=cover-grpc.out
+	go test -coverprofile=cover-http.out ./service/http && go tool cover -html=cover-http.out
 
 service: mod ## Runs the uncompiled example service code 
 	dapr run --app-id serving \

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,16 @@ service: mod ## Runs the uncompiled example service code
 			 --components-path example/serving/grpc/config \
 			 go run example/serving/grpc/main.go
 
-service09: mod ## Runs the uncompiled example service code using the Dapr v0.9 flags
+service09http: mod ## Runs the uncompiled HTTP example service code using the Dapr v0.9 flags
+	dapr run --app-id serving \
+			 --protocol http \
+			 --app-port 8080 \
+			 --port 3500 \
+			 --log-level debug \
+			 --components-path example/serving/http/config \
+			 go run example/serving/http/main.go
+
+service09grpc: mod ## Runs the uncompiled gRPC example service code using the Dapr v0.9 flags
 	dapr run --app-id serving \
 			 --protocol grpc \
 			 --app-port 50001 \

--- a/Readme.md
+++ b/Readme.md
@@ -181,7 +181,7 @@ handleErrors(err)
 
 ## Service (callback)
 
-In addition to a an easy to use client, Dapr go package also provides implementation for `service`. Instructions on how to use it are located [here](./service/grpc/Readme.md)
+In addition to a an easy to use client, Dapr go package also provides implementation for `service`. Instructions on how to use it are located [here](./service/Readme.md)
 
 
 ## Contributing to Dapr go client 

--- a/example/Readme.md
+++ b/example/Readme.md
@@ -2,7 +2,22 @@
 
 The `example` folder contains a Dapr enabled `serving` app and a `client` app that uses this SDK to invoke Dapr API for state and events, The `serving` app is available as HTTP or gRPC. The `client` app can target either one of these for service to service and binding invocations.
 
-To run this example, start by first launching the service:
+To run this example, start by first launching the service in ether HTTP or gRPC:
+
+### HTTP
+
+```
+cd example/serving/http
+dapr run --app-id serving \
+         --app-protocol http \
+         --app-port 8080 \
+         --port 3500 \
+         --log-level debug \
+         --components-path ./config \
+         go run main.go
+```
+
+### gRPC
 
 ```
 cd example/serving/grpc

--- a/example/serving/http/config/cron.yaml
+++ b/example/serving/http/config/cron.yaml
@@ -1,0 +1,9 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: run
+spec:
+  type: bindings.cron
+  metadata:
+  - name: schedule
+    value: "@every 10s"

--- a/example/serving/http/config/pubsub.yaml
+++ b/example/serving/http/config/pubsub.yaml
@@ -1,0 +1,11 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messages
+spec:
+  type: pubsub.redis
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""

--- a/example/serving/http/config/statestore.yaml
+++ b/example/serving/http/config/statestore.yaml
@@ -1,0 +1,13 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: actorStateStore
+    value: "true"

--- a/example/serving/http/main.go
+++ b/example/serving/http/main.go
@@ -4,35 +4,32 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
 
-	daprd "github.com/dapr/go-sdk/service/grpc"
+	daprd "github.com/dapr/go-sdk/service/http"
 )
 
 func main() {
-	// create a Dapr service server
-	s, err := daprd.NewService(":50001")
-	if err != nil {
-		log.Fatalf("failed to start the server: %v", err)
-	}
+	// create a Dapr service (e.g. ":8080", "0.0.0.0:8080", "10.1.1.1:8080" )
+	s := daprd.NewService(":8080")
 
 	// add some topic subscriptions
-	if err := s.AddTopicEventHandler("messages", eventHandler); err != nil {
+	if err := s.AddTopicEventHandler("messages", "/events", eventHandler); err != nil {
 		log.Fatalf("error adding topic subscription: %v", err)
 	}
 
 	// add a service to service invocation handler
-	if err := s.AddServiceInvocationHandler("echo", echoHandler); err != nil {
+	if err := s.AddServiceInvocationHandler("/echo", echoHandler); err != nil {
 		log.Fatalf("error adding invocation handler: %v", err)
 	}
 
-	// add a binding invocation handler
-	if err := s.AddBindingInvocationHandler("run", runHandler); err != nil {
+	// add an input binding invocation handler
+	if err := s.AddInputBindingHandler("/run", runHandler); err != nil {
 		log.Fatalf("error adding binding handler: %v", err)
 	}
 
-	// start the server
-	if err := s.Start(); err != nil {
-		log.Fatalf("server error: %v", err)
+	if err := s.Start(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("error listenning: %v", err)
 	}
 }
 

--- a/service/Readme.md
+++ b/service/Readme.md
@@ -1,0 +1,11 @@
+# Dapr Service (Callback) SDK for Go
+
+In addition to a an easy to use client, Dapr go package also provides implementation for `service` or `callback` in both HTTP and gRPC protocols:
+
+* [HTTP Service](./http/Readme.md)
+* [gRPC Service](./grpc/Readme.md)
+
+
+## Contributing
+
+See the [Contribution Guide](../CONTRIBUTING.md) to get started with building and developing.

--- a/service/grpc/service.go
+++ b/service/grpc/service.go
@@ -39,6 +39,7 @@ type TopicEvent struct {
 	// The content type of data value.
 	DataContentType string
 	// The content of the event.
+	// Note, this is why the gRPC and HTTP implementations need separate structs for cloud events.
 	Data interface{}
 	// Cloud event subject
 	Subject string

--- a/service/http/binding.go
+++ b/service/http/binding.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// AddInputBindingHandler appends provided binding invocation handler with its route to the service
+func (s *ServiceImp) AddInputBindingHandler(route string, fn func(ctx context.Context, in *BindingEvent) (out []byte, err error)) error {
+	if route == "" {
+		return fmt.Errorf("binding route required")
+	}
+
+	s.mux.Handle(route, optionsHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			var e BindingEvent
+			if r.ContentLength > 0 {
+				// deserialize the event
+				if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+			} else {
+				e = BindingEvent{}
+			}
+
+			// execute handler
+			out, err := fn(r.Context(), &e)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			if out == nil {
+				out = []byte("{}")
+			}
+
+			w.Header().Add("Content-Type", "application/json")
+			if _, err := w.Write(out); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		})))
+
+	return nil
+}

--- a/service/http/binding_test.go
+++ b/service/http/binding_test.go
@@ -1,0 +1,60 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBindingHandlerWithoutData(t *testing.T) {
+	t.Parallel()
+
+	s := newService("")
+	err := s.AddInputBindingHandler("/", func(ctx context.Context, in *BindingEvent) (out []byte, err error) {
+		if in == nil {
+			return nil, errors.New("nil input")
+		}
+		if in.Data != nil {
+			return nil, errors.New("invalid input data")
+		}
+		return nil, nil
+	})
+	assert.NoErrorf(t, err, "error adding binding event handler")
+
+	req, err := http.NewRequest(http.MethodPost, "/", nil)
+	assert.NoErrorf(t, err, "error creating request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	s.mux.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "{}", resp.Body.String())
+}
+
+func TestBindingHandlerWithData(t *testing.T) {
+	t.Parallel()
+
+	data := `{"name": "test"}`
+	s := newService("")
+	err := s.AddInputBindingHandler("/", func(ctx context.Context, in *BindingEvent) (out []byte, err error) {
+		if in == nil {
+			return nil, errors.New("nil input")
+		}
+		return []byte("test"), nil
+	})
+	assert.NoErrorf(t, err, "error adding binding event handler")
+
+	req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(data))
+	assert.NoErrorf(t, err, "error creating request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	s.mux.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "test", resp.Body.String())
+}

--- a/service/http/invoke.go
+++ b/service/http/invoke.go
@@ -1,0 +1,55 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// AddServiceInvocationHandler appends provided service invocation handler with its route to the service
+func (s *ServiceImp) AddServiceInvocationHandler(route string, fn func(ctx context.Context, in *InvocationEvent) (out *Content, err error)) error {
+	if route == "" {
+		return fmt.Errorf("service route required")
+	}
+
+	s.mux.Handle(route, optionsHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			// capture http args
+			e := &InvocationEvent{
+				Verb:        r.Method,
+				QueryString: r.URL.Query(),
+				ContentType: r.Header.Get("Content-type"),
+			}
+
+			// check for post with no data
+			if r.ContentLength > 0 {
+				content, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				e.Data = content
+			}
+
+			// execute handler
+			o, err := fn(r.Context(), e)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			// write to response if handler returned data
+			if o != nil && o.Data != nil {
+				if _, err := w.Write(o.Data); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				if o.ContentType != "" {
+					w.Header().Set("Content-type", o.ContentType)
+				}
+			}
+		})))
+
+	return nil
+}

--- a/service/http/invoke_test.go
+++ b/service/http/invoke_test.go
@@ -1,0 +1,89 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvocationHandlerWithData(t *testing.T) {
+	t.Parallel()
+
+	data := `{"name": "test", "data": hellow}`
+	s := newService("")
+	err := s.AddServiceInvocationHandler("/", func(ctx context.Context, in *InvocationEvent) (out *Content, err error) {
+		if in == nil || in.Data == nil || in.ContentType == "" {
+			err = errors.New("nil input")
+			return
+		}
+		out = &Content{
+			Data:        in.Data,
+			ContentType: in.ContentType,
+			DataTypeURL: in.DataTypeURL,
+		}
+		return
+	})
+	assert.NoErrorf(t, err, "error adding event handler")
+
+	req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(data))
+	assert.NoErrorf(t, err, "error creating request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	s.mux.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	b, err := ioutil.ReadAll(resp.Body)
+	assert.NoErrorf(t, err, "error reading response body")
+	assert.Equal(t, data, string(b))
+}
+
+func TestInvocationHandlerWithoutInputData(t *testing.T) {
+	t.Parallel()
+
+	s := newService("")
+	err := s.AddServiceInvocationHandler("/", func(ctx context.Context, in *InvocationEvent) (out *Content, err error) {
+		if in == nil || in.Data != nil {
+			err = errors.New("nil input")
+			return
+		}
+		return &Content{}, nil
+	})
+	assert.NoErrorf(t, err, "error adding event handler")
+
+	req, err := http.NewRequest(http.MethodPost, "/", nil)
+	assert.NoErrorf(t, err, "error creating request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	s.mux.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	b, err := ioutil.ReadAll(resp.Body)
+	assert.NoErrorf(t, err, "error reading response body")
+	assert.NotNil(t, b)
+	assert.Equal(t, "", string(b))
+}
+
+func TestInvocationHandlerWithInvalidRoute(t *testing.T) {
+	t.Parallel()
+
+	s := newService("")
+	err := s.AddServiceInvocationHandler("/a", func(ctx context.Context, in *InvocationEvent) (out *Content, err error) {
+		return nil, nil
+	})
+	assert.NoErrorf(t, err, "error adding event handler")
+
+	req, err := http.NewRequest(http.MethodPost, "/b", nil)
+	assert.NoErrorf(t, err, "error creating request")
+
+	resp := httptest.NewRecorder()
+	s.mux.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}

--- a/service/http/service.go
+++ b/service/http/service.go
@@ -1,0 +1,122 @@
+package http
+
+import (
+	"context"
+	"net/http"
+)
+
+// Service represents Dapr callback service
+type Service interface {
+	// AddServiceInvocationHandler appends provided service invocation handler with its name to the service.
+	AddServiceInvocationHandler(name string, fn func(ctx context.Context, in *InvocationEvent) (out *Content, err error)) error
+	// AddTopicEventHandler appends provided event handler with it's topic to the service
+	AddTopicEventHandler(topic, route string, fn func(ctx context.Context, e *TopicEvent) error) error
+	// AddInputBindingHandler appends provided binding invocation handler with its route to the service
+	AddInputBindingHandler(route string, fn func(ctx context.Context, in *BindingEvent) (out []byte, err error)) error
+	// Start starts service
+	Start() error
+}
+
+// TopicEvent is the content of the inbound topic message
+type TopicEvent struct {
+	// ID identifies the event.
+	ID string `json:"id"`
+	// The version of the CloudEvents specification.
+	SpecVersion string `json:"specversion"`
+	// The type of event related to the originating occurrence.
+	Type string `json:"type"`
+	// Source identifies the context in which an event happened.
+	Source string `json:"source"`
+	// The content type of data value.
+	DataContentType string `json:"datacontenttype"`
+	// The content of the event.
+	// Note, this is why the gRPC and HTTP implementations need separate structs for cloud events.
+	Data interface{} `json:"data"`
+	// Cloud event subject
+	Subject string `json:"subject"`
+	// The pubsub topic which publisher sent to.
+	Topic string `json:"topic"`
+}
+
+// InvocationEvent represents the input and output of binding invocation
+type InvocationEvent struct {
+	// Data is the payload that the input bindings sent.
+	Data []byte `json:"data"`
+	// ContentType of the Data
+	ContentType string `json:"contentType"`
+	// DataTypeURL is the resource URL that uniquely identifies the type of the serialized
+	DataTypeURL string `json:"typeUrl,omitempty"`
+	// Verb is the HTTP verb that was used to invoke this service.
+	Verb string `json:"-"`
+	// QueryString is the HTTP query string that was used to invoke this service.
+	QueryString map[string][]string `json:"-"`
+}
+
+// Content is a generic data content
+type Content struct {
+	// Data is the payload that the input bindings sent.
+	Data []byte `json:"data"`
+	// ContentType of the Data
+	ContentType string `json:"contentType"`
+	// DataTypeURL is the resource URL that uniquely identifies the type of the serialized
+	DataTypeURL string `json:"typeUrl,omitempty"`
+}
+
+// BindingEvent represents the binding event handler input
+type BindingEvent struct {
+	// Data is the input bindings sent
+	Data []byte `json:"data"`
+	// Metadata is the input binging components
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// Subscription represents single topic subscription
+type Subscription struct {
+	// Topic is the name of the topic
+	Topic string `json:"topic"`
+	// Route is the route of the handler where topic events should be published
+	Route string `json:"route"`
+}
+
+// NewService creates new Service
+func NewService(address string) Service {
+	return newService(address)
+}
+
+func newService(address string) *ServiceImp {
+	return &ServiceImp{
+		address:            address,
+		mux:                http.NewServeMux(),
+		topicSubscriptions: make([]*Subscription, 0),
+	}
+}
+
+// ServiceImp is the HTTP server wrapping mux many Dapr helpers
+type ServiceImp struct {
+	address            string
+	mux                *http.ServeMux
+	topicSubscriptions []*Subscription
+}
+
+// Start starts the HTTP handler. Blocks while serving
+func (s *ServiceImp) Start() error {
+	s.registerSubscribeHandler()
+	server := http.Server{
+		Addr:    s.address,
+		Handler: s.mux,
+	}
+	return server.ListenAndServe()
+}
+
+func optionsHandler(h http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "POST,OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "authorization, origin, content-type, accept")
+			w.Header().Set("Allow", "POST,OPTIONS")
+		} else {
+			h.ServeHTTP(w, r)
+		}
+	}
+}

--- a/service/http/service_test.go
+++ b/service/http/service_test.go
@@ -1,0 +1,13 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoppingUnstartedService(t *testing.T) {
+	t.Parallel()
+	s := newService("")
+	assert.NotNil(t, s)
+}

--- a/service/http/topic.go
+++ b/service/http/topic.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func (s *ServiceImp) registerSubscribeHandler() {
+	f := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(s.topicSubscriptions); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	s.mux.HandleFunc("/dapr/subscribe", f)
+}
+
+// AddTopicEventHandler appends provided event handler with it's name to the service
+func (s *ServiceImp) AddTopicEventHandler(topic, route string, fn func(ctx context.Context, e *TopicEvent) error) error {
+	if topic == "" {
+		return errors.New("topic name required")
+	}
+
+	if route == "" {
+		return errors.New("handler route name")
+	}
+
+	sub := &Subscription{Topic: topic, Route: route}
+	s.topicSubscriptions = append(s.topicSubscriptions, sub)
+
+	s.mux.Handle(route, optionsHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			// check for post with no data
+			if r.ContentLength == 0 {
+				http.Error(w, "nil content", http.StatusBadRequest)
+				return
+			}
+
+			// deserialize the event
+			var in TopicEvent
+			if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+				fmt.Println(err.Error())
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			if in.Topic == "" {
+				in.Topic = topic
+			}
+
+			if err := fn(r.Context(), &in); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+		})))
+
+	return nil
+}

--- a/service/http/topic_test.go
+++ b/service/http/topic_test.go
@@ -1,0 +1,55 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventHandler(t *testing.T) {
+	t.Parallel()
+
+	data := `{
+		"specversion" : "1.0",
+		"type" : "com.github.pull.create",
+		"source" : "https://github.com/cloudevents/spec/pull",
+		"subject" : "123",
+		"id" : "A234-1234-1234",
+		"time" : "2018-04-05T17:31:00Z",
+		"comexampleextension1" : "value",
+		"comexampleothervalue" : 5,
+		"datacontenttype" : "application/json",
+		"data" : "eyJtZXNzYWdlIjoiaGVsbG8ifQ=="
+	}`
+
+	s := newService("")
+
+	err := s.AddTopicEventHandler("test", "/", func(ctx context.Context, e *TopicEvent) error {
+		if e == nil {
+			return errors.New("nil content")
+		}
+		if e.DataContentType != "application/json" {
+			return fmt.Errorf("invalid content type: %s", e.DataContentType)
+		}
+		if e.Data == nil {
+			return errors.New("nil data")
+		}
+		return nil
+	})
+	assert.NoErrorf(t, err, "error adding event handler")
+
+	req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(data))
+	assert.NoErrorf(t, err, "error creating request")
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	s.registerSubscribeHandler()
+	s.mux.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}


### PR DESCRIPTION
This is the HTTP implementation of the serving side outlined in #26. The updating example that goes with this PR uses this capability and does simplify the creation of HTTP services.