### PR TITLE
cleans up log entry in examples

### DIFF
--- a/example/serving/grpc/main.go
+++ b/example/serving/grpc/main.go
@@ -42,7 +42,7 @@ func main() {
 }
 
 func eventHandler(ctx context.Context, e *common.TopicEvent) error {
-	log.Printf("event - PubsubName:%s, Topic:%s, ID:%s, Data: %v", e.PubsubName, e.Topic, e.ID, e.Data)
+	log.Printf("event - PubsubName:%s, Topic:%s, ID:%s, Data: %s", e.PubsubName, e.Topic, e.ID, e.Data)
 	return nil
 }
 
@@ -52,8 +52,8 @@ func echoHandler(ctx context.Context, in *common.InvocationEvent) (out *common.C
 		return
 	}
 	log.Printf(
-		"echo - ContentType:%s, Verb:%s, QueryString:%s, %+v",
-		in.ContentType, in.Verb, in.QueryString, string(in.Data),
+		"echo - ContentType:%s, Verb:%s, QueryString:%s, %s",
+		in.ContentType, in.Verb, in.QueryString, in.Data,
 	)
 	out = &common.Content{
 		Data:        in.Data,
@@ -64,6 +64,6 @@ func echoHandler(ctx context.Context, in *common.InvocationEvent) (out *common.C
 }
 
 func runHandler(ctx context.Context, in *common.BindingEvent) (out []byte, err error) {
-	log.Printf("binding - Data:%v, Meta:%v", in.Data, in.Metadata)
+	log.Printf("binding - Data:%s, Meta:%v", in.Data, in.Metadata)
 	return nil, nil
 }

--- a/example/serving/http/main.go
+++ b/example/serving/http/main.go
@@ -40,7 +40,7 @@ func main() {
 }
 
 func eventHandler(ctx context.Context, e *common.TopicEvent) error {
-	log.Printf("event - PubsubName:%s, Topic:%s, ID:%s, Data: %v", e.PubsubName, e.Topic, e.ID, e.Data)
+	log.Printf("event - PubsubName:%s, Topic:%s, ID:%s, Data: %s", e.PubsubName, e.Topic, e.ID, e.Data)
 	return nil
 }
 
@@ -50,8 +50,8 @@ func echoHandler(ctx context.Context, in *common.InvocationEvent) (out *common.C
 		return
 	}
 	log.Printf(
-		"echo - ContentType:%s, Verb:%s, QueryString:%s, %+v",
-		in.ContentType, in.Verb, in.QueryString, string(in.Data),
+		"echo - ContentType:%s, Verb:%s, QueryString:%s, %s",
+		in.ContentType, in.Verb, in.QueryString, in.Data,
 	)
 	out = &common.Content{
 		Data:        in.Data,
@@ -62,6 +62,6 @@ func echoHandler(ctx context.Context, in *common.InvocationEvent) (out *common.C
 }
 
 func runHandler(ctx context.Context, in *common.BindingEvent) (out []byte, err error) {
-	log.Printf("binding - Data:%v, Meta:%v", in.Data, in.Metadata)
+	log.Printf("binding - Data:%s, Meta:%v", in.Data, in.Metadata)
 	return nil, nil
 }


### PR DESCRIPTION
Nice (consistent across HTTP and gRPC) formatting for the example log entries

JSON Content 

```shell
Event - PubsubName:messages, Topic:topic1, ID:3fec7421-d947-41cf-ac9c-3b614b316358, Data: {"to":"Lary","message":"hi","from":"John"}
```

XML Content 

```shell
Event - PubsubName:messages, Topic:topic1, ID:1f40a77c-8091-4267-bd5f-ff7bc1835ff8, Data: <message><from>John</from><to>Lary</to></message>
```

BIN Content

```shell
Event - PubsubName:messages, Topic:topic1, ID:179f4711-95d6-4558-b6f7-3422f35b4e10, Data: 0x18, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x09, 0x40
```