### PR TITLE
dep cache in test/release actions

### DIFF
--- a/.github/workflows/release-on-tag.yaml
+++ b/.github/workflows/release-on-tag.yaml
@@ -22,6 +22,16 @@ jobs:
       id: setup
       uses: actions/checkout@v2
 
+    - name: Cache
+      uses: actions/cache@preview
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.OS }}-build-${{ env.cache-name }}-
+          ${{ runner.OS }}-build-
+          ${{ runner.OS }}-
+
     - name: Tidy
       run: |
         go mod tidy 

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -20,6 +20,16 @@ jobs:
       id: setup
       uses: actions/checkout@v2
 
+    - name: Cache
+      uses: actions/cache@preview
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.OS }}-build-${{ env.cache-name }}-
+          ${{ runner.OS }}-build-
+          ${{ runner.OS }}-
+
     - name: Tidy
       run: |
         go mod tidy 


### PR DESCRIPTION
the repo doesn't have many dependencies to vendor, still, the go.sum based cache cuts the test builds by ~20%