### PR TITLE
[doc] Use the latest options for port

### DIFF
--- a/example/Readme.md
+++ b/example/Readme.md
@@ -11,7 +11,7 @@ cd example/serving/http
 dapr run --app-id serving \
          --app-protocol http \
          --app-port 8080 \
-         --port 3500 \
+         --dapr-http-port 3500 \
          --log-level debug \
          --components-path ./config \
          go run main.go
@@ -24,7 +24,7 @@ cd example/serving/grpc
 dapr run --app-id serving \
          --app-protocol grpc \
          --app-port 50001 \
-         --port 3500 \
+         --dapr-grpc-port 3500 \
          --log-level debug \
          --components-path ./config \
          go run main.go
@@ -39,7 +39,7 @@ cd example/client
 dapr run --app-id caller \
          --components-path ./config \
          --log-level debug \
-         go run main.go 
+         go run main.go
 ```
 
 ## API

--- a/example/pubsub/README.md
+++ b/example/pubsub/README.md
@@ -21,7 +21,7 @@ dapr run --app-id sub \
          --dapr-http-port 3500 \
          --log-level debug \
          --components-path ../config \
-         go run sub.go 
+         go run sub.go
 ```
 
 ### Run Publisher
@@ -36,7 +36,7 @@ Please change directory to pubsub/pub and run the following command:
 dapr run --app-id pub \
          --log-level debug \
          --components-path ../config \
-         go run pub.go 
+         go run pub.go
 ```
 
 ## Result


### PR DESCRIPTION
Use `dapr-http-port` and `dapr-grpc-port` instead of `port`