### PR TITLE
rename SaveStateItems() and GetStateItems()

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -54,17 +54,17 @@ type Client interface {
 	// SaveState saves the raw data into store using default state options.
 	SaveState(ctx context.Context, store, key string, data []byte) error
 
-	// SaveStateItems saves multiple state item to store with specified options.
-	SaveStateItems(ctx context.Context, store string, items ...*SetStateItem) error
+	// SaveBulkState saves multiple state item to store with specified options.
+	SaveBulkState(ctx context.Context, store string, items ...*SetStateItem) error
 
-	// GetState retreaves state from specific store using default consistency option.
+	// GetState retrieves state from specific store using default consistency option.
 	GetState(ctx context.Context, store, key string) (item *StateItem, err error)
 
-	// GetStateWithConsistency retreaves state from specific store using provided state consistency.
+	// GetStateWithConsistency retrieves state from specific store using provided state consistency.
 	GetStateWithConsistency(ctx context.Context, store, key string, meta map[string]string, sc StateConsistency) (item *StateItem, err error)
 
-	// GetBulkItems retreaves state for multiple keys from specific store.
-	GetBulkItems(ctx context.Context, store string, keys []string, parallelism int32) ([]*StateItem, error)
+	// GetBulkState retrieves state for multiple keys from specific store.
+	GetBulkState(ctx context.Context, store string, keys []string, parallelism int32) ([]*StateItem, error)
 
 	// DeleteState deletes content from store using default state options.
 	DeleteState(ctx context.Context, store, key string) error

--- a/client/state.go
+++ b/client/state.go
@@ -184,11 +184,11 @@ func (c *GRPCClient) ExecuteStateTransaction(ctx context.Context, store string, 
 // SaveState saves the raw data into store using default state options.
 func (c *GRPCClient) SaveState(ctx context.Context, store, key string, data []byte) error {
 	item := &SetStateItem{Key: key, Value: data}
-	return c.SaveStateItems(ctx, store, item)
+	return c.SaveBulkState(ctx, store, item)
 }
 
 // SaveStateItems saves the multiple state item to store.
-func (c *GRPCClient) SaveStateItems(ctx context.Context, store string, items ...*SetStateItem) error {
+func (c *GRPCClient) SaveBulkState(ctx context.Context, store string, items ...*SetStateItem) error {
 	if store == "" {
 		return errors.New("nil store")
 	}
@@ -215,7 +215,7 @@ func (c *GRPCClient) SaveStateItems(ctx context.Context, store string, items ...
 }
 
 // GetBulkItems retreaves state for multiple keys from specific store.
-func (c *GRPCClient) GetBulkItems(ctx context.Context, store string, keys []string, parallelism int32) ([]*StateItem, error) {
+func (c *GRPCClient) GetBulkState(ctx context.Context, store string, keys []string, parallelism int32) ([]*StateItem, error) {
 	if store == "" {
 		return nil, errors.New("nil store")
 	}

--- a/client/state_test.go
+++ b/client/state_test.go
@@ -72,7 +72,7 @@ func TestSaveState(t *testing.T) {
 			Key:   key,
 			Value: []byte(data),
 		}
-		err := testClient.SaveStateItems(ctx, store, item)
+		err := testClient.SaveBulkState(ctx, store, item)
 		assert.Nil(t, err)
 	})
 
@@ -126,7 +126,7 @@ func TestDeleteState(t *testing.T) {
 	})
 
 	t.Run("save data again with etag, meta", func(t *testing.T) {
-		err := testClient.SaveStateItems(ctx, store, &SetStateItem{
+		err := testClient.SaveBulkState(ctx, store, &SetStateItem{
 			Key:      key,
 			Value:    []byte(data),
 			Etag:     "100",
@@ -185,7 +185,7 @@ func TestStateTransactions(t *testing.T) {
 	})
 
 	t.Run("exec upserts", func(t *testing.T) {
-		items, err := testClient.GetBulkItems(ctx, store, keys, 10)
+		items, err := testClient.GetBulkState(ctx, store, keys, 10)
 		assert.Nil(t, err)
 		assert.NotNil(t, items)
 		assert.Len(t, items, len(keys))
@@ -207,7 +207,7 @@ func TestStateTransactions(t *testing.T) {
 	})
 
 	t.Run("get and validate inserts", func(t *testing.T) {
-		items, err := testClient.GetBulkItems(ctx, store, keys, 10)
+		items, err := testClient.GetBulkState(ctx, store, keys, 10)
 		assert.Nil(t, err)
 		assert.NotNil(t, items)
 		assert.Len(t, items, len(keys))
@@ -224,7 +224,7 @@ func TestStateTransactions(t *testing.T) {
 	})
 
 	t.Run("ensure deletes", func(t *testing.T) {
-		items, err := testClient.GetBulkItems(ctx, store, keys, 3)
+		items, err := testClient.GetBulkState(ctx, store, keys, 3)
 		assert.Nil(t, err)
 		assert.NotNil(t, items)
 		assert.Len(t, items, 0)

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -55,7 +55,7 @@ func main() {
 			Consistency: dapr.StateConsistencyStrong,
 		},
 	}
-	if err := client.SaveStateItems(ctx, store, item2); err != nil {
+	if err := client.SaveBulkState(ctx, store, item2); err != nil {
 		panic(err)
 	}
 	fmt.Println("data item saved")


### PR DESCRIPTION
- rename SaveStateItems() to SaveBulkState(); 
- rename GetStateItems() to GetBulkState();

As discussed in this Issue:

https://github.com/dapr/dapr/issues/2368

