### PR TITLE
optimize: state consistency from strong to eventual

### DIFF
--- a/client/state.go
+++ b/client/state.go
@@ -89,7 +89,7 @@ func (c StateConcurrency) String() string {
 var (
 	stateOptionDefault = &v1.StateOptions{
 		Concurrency: v1.StateOptions_CONCURRENCY_LAST_WRITE,
-		Consistency: v1.StateOptions_CONSISTENCY_STRONG,
+		Consistency: v1.StateOptions_CONSISTENCY_EVENTUAL,
 	}
 )
 


### PR DESCRIPTION
When we use go-sdk's GetState, we don't know consistency default rules.  

i use GetState method  it running ok in redis test environment, but i publish server to production  environment , redis configuration permissions reduced to cause bellow failed. This is a fatal problem.

```shell
(error) ERR unkown command 'WAIT' or wrong number of arguments
```

![image](https://user-images.githubusercontent.com/20457624/115198093-4563e000-a124-11eb-82cd-58c23851ab42.png)
