### PR TITLE
feat(state): SaveState expose StateOptions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,7 @@ ctx := context.Background()
 data := []byte("hello")
 store := "my-store" // defined in the component YAML 
 
-// save state with the key key1
+// save state with the key key1, default options: strong, last-write
 if err := client.SaveState(ctx, store, "key1", data); err != nil {
     panic(err)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -62,7 +62,7 @@ type Client interface {
 	GetBulkSecret(ctx context.Context, storeName string, meta map[string]string) (data map[string]map[string]string, err error)
 
 	// SaveState saves the raw data into store using default state options.
-	SaveState(ctx context.Context, storeName, key string, data []byte) error
+	SaveState(ctx context.Context, storeName, key string, data []byte, so ...StateOption) error
 
 	// SaveBulkState saves multiple state item to store with specified options.
 	SaveBulkState(ctx context.Context, storeName string, items ...*SetStateItem) error

--- a/client/state.go
+++ b/client/state.go
@@ -89,7 +89,7 @@ func (c StateConcurrency) String() string {
 var (
 	stateOptionDefault = &v1.StateOptions{
 		Concurrency: v1.StateOptions_CONCURRENCY_LAST_WRITE,
-		Consistency: v1.StateOptions_CONSISTENCY_STRONG,
+		Consistency: v1.StateOptions_CONSISTENCY_EVENTUAL,
 	}
 )
 

--- a/client/state.go
+++ b/client/state.go
@@ -99,7 +99,7 @@ func (c StateConcurrency) String() string {
 var (
 	stateOptionDefault = &v1.StateOptions{
 		Concurrency: v1.StateOptions_CONCURRENCY_LAST_WRITE,
-		Consistency: v1.StateOptions_CONSISTENCY_EVENTUAL,
+		Consistency: v1.StateOptions_CONSISTENCY_STRONG,
 	}
 )
 


### PR DESCRIPTION
When we use go-sdk's GetState, we don't know consistency default rules.

i use GetState method it running ok in redis test environment, but i publish server to production environment , redis configuration permissions reduced to cause bellow failed. This is a fatal problem.

```shell
(error) ERR unkown command 'WAIT' or wrong number of arguments
```

![image](https://user-images.githubusercontent.com/20457624/115204178-c7570780-a12a-11eb-98ed-8f9f2ccb324b.png)
