### PR TITLE
Added Server.Unwrap function

### DIFF
--- a/service/http/service.go
+++ b/service/http/service.go
@@ -44,6 +44,11 @@ func (s *Server) Start() error {
 	return server.ListenAndServe()
 }
 
+// Gets the underlying serve address and http.ServeMux
+func (s *Server) Unwrap() (string, *http.ServeMux) {
+	return s.address, s.mux
+}
+
 // Stop stops previously started HTTP service
 func (s *Server) Stop() error {
 	// TODO: implement service stop


### PR DESCRIPTION
This is a tiny commit, mostly for internal use.

I did it to support adding middlewares (such as logging, which is my case) over the http.ServeMux generated by the Dapr SDK.

It is probably not the cleanest way to do that though, as you still need to cast the `daprd.NewServiceWithMux()` output with `s.(*daprd.Server)`