### PR TITLE
Do not wrap errors for invocations

### DIFF
--- a/client/invoke.go
+++ b/client/invoke.go
@@ -26,7 +26,7 @@ func (c *GRPCClient) invokeServiceWithRequest(ctx context.Context, req *pb.Invok
 
 	resp, err := c.protoClient.InvokeService(c.withAuthToken(ctx), req)
 	if err != nil {
-		return nil, errors.Wrap(err, "error invoking service")
+		return nil, err
 	}
 
 	// allow for service to not return any value

--- a/service/grpc/invoke.go
+++ b/service/grpc/invoke.go
@@ -43,7 +43,7 @@ func (s *Server) OnInvoke(ctx context.Context, in *cpb.InvokeRequest) (*cpb.Invo
 
 		ct, er := fn(ctx, e)
 		if er != nil {
-			return nil, errors.Wrap(er, "error executing handler")
+			return nil, er
 		}
 
 		if ct == nil {


### PR DESCRIPTION
On both client and server, this does not call `errors.Wrap` on errors, so the original gRPC error object (with status code and message) is preserved.

Fixes #186