### PR TITLE
Add documentation and example to deal with gRPC 4mb limit

### DIFF
--- a/examples/service/Makefile
+++ b/examples/service/Makefile
@@ -27,6 +27,14 @@ client: ## Runs the uncompiled example client code
              --log-level debug \
              go run ./client/main.go 
 
+.PHONY: custom-grpc-client
+custom-grpc-client: ## Runs the uncompiled example custom grpc client code
+	dapr run --app-id custom-grpc-client \
+		 -d ./config \
+		 --dapr-http-max-request-size 41 \
+		 --log-level debug \
+		 go run ./custom-grpc-client/main.go
+
 .PHONY: publish
 publish: ## Submits pub/sub events in different content types 
 	curl -i -d '{ "from": "John", "to": "Lary", "message": "hi" }' \

--- a/examples/service/README.md
+++ b/examples/service/README.md
@@ -73,35 +73,6 @@ dapr run --app-id caller \
 
 <!-- END_STEP -->
 
-## Custom gRPC client
-
-Launch the DAPR client with custom gRPC client to accept and receive payload size > 4 MB:
-<!-- STEP
-expected_stdout_lines:
-✅  You're up and running! Both Dapr and your app logs will appear here.
-
-== APP == Writing large data blob...
-== APP == Saved the large data blob...
-== APP == Writing to statestore took 1.29516369sGetting data from the large data blob...
-== APP == Reading from statestore took 3.735723404s
-== APP == Deleting key from statestore took 3.738843037s
-== APP == DONE (CTRL+C to Exit)
-✅  Exited App successfully
-ℹ️  
-terminated signal received: shutting down
-✅  Exited Dapr successfully
--->
-
-```bash
-dapr run --app-id custom-grpc-client \
-		 -d ./config \
-		 --dapr-http-max-request-size 41 \
-		 --log-level debug \
-		 go run ./custom-grpc-client/main.go
-```
-
-<!-- END_STEP -->
-
 ## API
 
 ### PubSub
@@ -170,6 +141,36 @@ name: Shutdown dapr
 
 ```bash
 dapr stop --app-id serving
+```
+
+<!-- END_STEP -->
+
+## Custom gRPC client
+
+Launch the DAPR client with custom gRPC client to accept and receive payload size > 4 MB:
+
+<!-- STEP
+expected_stdout_lines:
+✅  You're up and running! Both Dapr and your app logs will appear here.
+
+== APP == Writing large data blob...
+== APP == Saved the large data blob...
+== APP == Writing to statestore took 1.29516369sGetting data from the large data blob...
+== APP == Reading from statestore took 3.735723404s
+== APP == Deleting key from statestore took 3.738843037s
+== APP == DONE (CTRL+C to Exit)
+✅  Exited App successfully
+ℹ️  
+terminated signal received: shutting down
+✅  Exited Dapr successfully
+-->
+
+```bash
+dapr run --app-id custom-grpc-client \
+		 -d ./config \
+		 --dapr-http-max-request-size 41 \
+		 --log-level debug \
+		 go run ./custom-grpc-client/main.go
 ```
 
 <!-- END_STEP -->

--- a/examples/service/README.md
+++ b/examples/service/README.md
@@ -1,8 +1,6 @@
 # Dapr Go client example
 
-The `examples/service` folder contains a Dapr enabled `serving` app and a `client` app that uses this SDK to invoke Dapr
-API for state and events, The `serving` app is available as HTTP or gRPC. The `client` app can target either one of
-these for service to service and binding invocations.
+The `examples/service` folder contains a Dapr enabled `serving` app and a `client` app that uses this SDK to invoke Dapr API for state and events, The `serving` app is available as HTTP or gRPC. The `client` app can target either one of these for service to service and binding invocations.
 
 To run this example, start by first launching the service in either HTTP or gRPC:
 
@@ -69,6 +67,36 @@ dapr run --app-id caller \
          --components-path ./config \
          --log-level debug \
          go run ./client/main.go
+```
+
+<!-- END_STEP -->
+
+## Custom gRPC client
+
+Launch the DAPR client with custom gRPC client to accept and receive payload size > 4 MB:
+
+<!-- STEP
+expected_stdout_lines:
+✅  You're up and running! Both Dapr and your app logs will appear here.
+
+== APP == Writing large data blob...
+== APP == Saved the large data blob...
+== APP == Writing to statestore took 1.29516369sGetting data from the large data blob...
+== APP == Reading from statestore took 3.735723404s
+== APP == Deleting key from statestore took 3.738843037s
+== APP == DONE (CTRL+C to Exit)
+✅  Exited App successfully
+ℹ️  
+terminated signal received: shutting down
+✅  Exited Dapr successfully
+-->
+
+```bash
+dapr run --app-id custom-grpc-client \
+		 -d ./config \
+		 --dapr-http-max-request-size 41 \
+		 --log-level debug \
+		 go run ./custom-grpc-client/main.go
 ```
 
 <!-- END_STEP -->
@@ -145,32 +173,3 @@ dapr stop --app-id serving
 
 <!-- END_STEP -->
 
-## Custom gRPC client
-
-Launch the DAPR client with custom gRPC client to accept and receive payload size > 4 MB:
-
-<!-- STEP
-expected_stdout_lines:
-✅  You're up and running! Both Dapr and your app logs will appear here.
-
-== APP == Writing large data blob...
-== APP == Saved the large data blob...
-== APP == Writing to statestore took 1.29516369sGetting data from the large data blob...
-== APP == Reading from statestore took 3.735723404s
-== APP == Deleting key from statestore took 3.738843037s
-== APP == DONE (CTRL+C to Exit)
-✅  Exited App successfully
-ℹ️  
-terminated signal received: shutting down
-✅  Exited Dapr successfully
--->
-
-```bash
-dapr run --app-id custom-grpc-client \
-		 -d ./config \
-		 --dapr-http-max-request-size 41 \
-		 --log-level debug \
-		 go run ./custom-grpc-client/main.go
-```
-
-<!-- END_STEP -->

--- a/examples/service/README.md
+++ b/examples/service/README.md
@@ -1,6 +1,8 @@
 # Dapr Go client example
 
-The `examples/service` folder contains a Dapr enabled `serving` app and a `client` app that uses this SDK to invoke Dapr API for state and events, The `serving` app is available as HTTP or gRPC. The `client` app can target either one of these for service to service and binding invocations.
+The `examples/service` folder contains a Dapr enabled `serving` app and a `client` app that uses this SDK to invoke Dapr
+API for state and events, The `serving` app is available as HTTP or gRPC. The `client` app can target either one of
+these for service to service and binding invocations.
 
 To run this example, start by first launching the service in either HTTP or gRPC:
 
@@ -43,7 +45,7 @@ dapr run --app-id serving \
          go run ./serving/grpc/main.go
 ```
 
-## Client 
+## Client
 
 Once one of the above services is running, launch the client:
 
@@ -71,6 +73,35 @@ dapr run --app-id caller \
 
 <!-- END_STEP -->
 
+## Custom gRPC client
+
+Launch the DAPR client with custom gRPC client to accept and receive payload size > 4 MB:
+<!-- STEP
+expected_stdout_lines:
+✅  You're up and running! Both Dapr and your app logs will appear here.
+
+== APP == Writing large data blob...
+== APP == Saved the large data blob...
+== APP == Writing to statestore took 1.29516369sGetting data from the large data blob...
+== APP == Reading from statestore took 3.735723404s
+== APP == Deleting key from statestore took 3.738843037s
+== APP == DONE (CTRL+C to Exit)
+✅  Exited App successfully
+ℹ️  
+terminated signal received: shutting down
+✅  Exited Dapr successfully
+-->
+
+```bash
+dapr run --app-id custom-grpc-client \
+		 -d ./config \
+		 --dapr-http-max-request-size 41 \
+		 --log-level debug \
+		 go run ./custom-grpc-client/main.go
+```
+
+<!-- END_STEP -->
+
 ## API
 
 ### PubSub
@@ -91,7 +122,7 @@ curl -d '<message><from>John</from><to>Lary</to></message>' \
      "http://localhost:3500/v1.0/publish/messages/topic1"
 ```
 
-Publish BIN content 
+Publish BIN content
 
 ```shell
 curl -d '0x18, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x09, 0x40' \
@@ -99,7 +130,7 @@ curl -d '0x18, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x09, 0x40' \
      "http://localhost:3500/v1.0/publish/messages/topic1"
 ```
 
-### Service Invocation 
+### Service Invocation
 
 Invoke service with JSON payload
 
@@ -124,7 +155,7 @@ curl -X DELETE \
     "http://localhost:3500/v1.0/invoke/serving/method/echo?k1=v1&k2=v2"
 ```
 
-### Input Binding  
+### Input Binding
 
 Uses the [config/cron.yaml](config/cron.yaml) component
 

--- a/examples/service/README.md
+++ b/examples/service/README.md
@@ -76,19 +76,14 @@ dapr run --app-id caller \
 Launch the DAPR client with custom gRPC client to accept and receive payload size > 4 MB:
 
 <!-- STEP
+output_match_mode: substring
 expected_stdout_lines:
-✅  You're up and running! Both Dapr and your app logs will appear here.
-
-== APP == Writing large data blob...
-== APP == Saved the large data blob...
-== APP == Writing to statestore took 1.29516369sGetting data from the large data blob...
-== APP == Reading from statestore took 3.735723404s
-== APP == Deleting key from statestore took 3.738843037s
-== APP == DONE (CTRL+C to Exit)
-✅  Exited App successfully
-ℹ️  
-terminated signal received: shutting down
-✅  Exited Dapr successfully
+  - '== APP == Writing large data blob'
+  - '== APP == Saved the large data blob'
+  - '== APP == Writing to statestore took'
+  - '== APP == Reading from statestore took'
+  - '== APP == Deleting key from statestore took'
+  - '== APP == DONE (CTRL+C to Exit)'
 -->
 
 ```bash

--- a/examples/service/custom-grpc-client/main.go
+++ b/examples/service/custom-grpc-client/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"google.golang.org/grpc"
+	"net"
+	"os"
+	"time"
+
+	dapr "github.com/dapr/go-sdk/client"
+)
+
+func GetEnvValue(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func main() {
+	// Testing 40 MB data exchange
+	maxRequestBodySize := 40
+	var opts []grpc.CallOption
+
+	// Receive 40 MB + 1 MB (data + headers overhead) exchange
+	headerBuffer := 1
+	opts = append(opts, grpc.MaxCallRecvMsgSize((maxRequestBodySize+headerBuffer)*1024*1024))
+	conn, err := grpc.Dial(net.JoinHostPort("127.0.0.1",
+		GetEnvValue("DAPR_GRPC_PORT", "50001")),
+		grpc.WithDefaultCallOptions(opts...), grpc.WithInsecure())
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Instantiate DAPR client with custom-grpc-client gRPC connection
+	client := dapr.NewClientWithConnection(conn)
+	defer client.Close()
+
+	ctx := context.Background()
+	start := time.Now()
+
+	fmt.Println("Writing large data blob...")
+	data := make([]byte, maxRequestBodySize*1024*1024)
+	store := "statestore" // defined in the component YAML
+	key := "my_key"
+
+	// save state with the key my_key, default options: strong, last-write
+	if err := client.SaveState(ctx, store, key, data); err != nil {
+		panic(err)
+	}
+	fmt.Println("Saved the large data blob...")
+	elapsed := time.Since(start)
+	fmt.Printf("Writing to statestore took %s", elapsed)
+
+	// get state for key my_key
+	fmt.Println("Getting data from the large data blob...")
+	_, err = client.GetState(ctx, store, key)
+	if err != nil {
+		panic(err)
+	}
+	elapsed2 := time.Since(start)
+	fmt.Printf("Reading from statestore took %s\n", elapsed2)
+
+	// delete state for key my_key
+	if err := client.DeleteState(ctx, store, key); err != nil {
+		panic(err)
+	}
+	elapsed3 := time.Since(start)
+	fmt.Printf("Deleting key from statestore took %s\n", elapsed3)
+
+	fmt.Println("DONE (CTRL+C to Exit)")
+}


### PR DESCRIPTION
The approach is documented to deal with 4MB gRPC limit on client side with DAPR client.

https://github.com/dapr/go-sdk/issues/189

1. Example `examples/service/custom-grpc-client/main.go` have been added working demo.
2. The README is updated at this location `examples/service/README.md`
3. Entry in Makefile to run the example.
