### PR TITLE
Implement HTTP service stop with a 5 sec timeout

### DIFF
--- a/service/http/service.go
+++ b/service/http/service.go
@@ -24,7 +24,7 @@ func newServer(address string, mux *http.ServeMux) *Server {
 	}
 	return &Server{
 		address: address,
-		http_server: &http.Server{
+		httpServer: &http.Server{
 			Addr:    address,
 			Handler: mux,
 		},
@@ -37,14 +37,14 @@ func newServer(address string, mux *http.ServeMux) *Server {
 type Server struct {
 	address            string
 	mux                *http.ServeMux
-	http_server        *http.Server
+	httpServer         *http.Server
 	topicSubscriptions []*common.Subscription
 }
 
 // Start starts the HTTP handler. Blocks while serving.
 func (s *Server) Start() error {
 	s.registerSubscribeHandler()
-	return s.http_server.ListenAndServe()
+	return s.httpServer.ListenAndServe()
 }
 
 // Stop stops previously started HTTP service with a five second timeout.
@@ -52,7 +52,7 @@ func (s *Server) Stop() error {
 	ctxShutDown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	return s.http_server.Shutdown(ctxShutDown)
+	return s.httpServer.Shutdown(ctxShutDown)
 }
 
 func setOptions(w http.ResponseWriter, r *http.Request) {

--- a/service/http/service.go
+++ b/service/http/service.go
@@ -47,12 +47,10 @@ func (s *Server) Start() error {
 	return s.http_server.ListenAndServe()
 }
 
-// Stop stops previously started HTTP service.
+// Stop stops previously started HTTP service with a five second timeout.
 func (s *Server) Stop() error {
 	ctxShutDown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer func() {
-		cancel()
-	}()
+	defer cancel()
 
 	return s.http_server.Shutdown(ctxShutDown)
 }

--- a/service/http/service_test.go
+++ b/service/http/service_test.go
@@ -33,12 +33,12 @@ func TestStoppingStartedService(t *testing.T) {
 func TestStartingStoppedService(t *testing.T) {
 	s := newServer(":3333", nil)
 	assert.NotNil(t, s)
-	stop_err := s.Stop()
-	assert.NoError(t, stop_err)
+	stopErr := s.Stop()
+	assert.NoError(t, stopErr)
 
-	start_err := s.Start()
-	assert.Error(t, start_err, "expected starting a stopped server to raise an error")
-	assert.Equal(t, start_err.Error(), http.ErrServerClosed.Error())
+	startErr := s.Start()
+	assert.Error(t, startErr, "expected starting a stopped server to raise an error")
+	assert.Equal(t, startErr.Error(), http.ErrServerClosed.Error())
 }
 
 func TestSettingOptions(t *testing.T) {


### PR DESCRIPTION
This addresses https://github.com/dapr/go-sdk/issues/208. It implements the `Stop` method on the HTTP service which is currently a [no-op with a `TODO` comment](https://github.com/dapr/go-sdk/blob/main/service/http/service.go#L49).

It sets a 5 second timeout for the shutdown process. Open to suggestions to avoid the `time.Sleep` in the tests or for a more appropriate shutdown timeout. Thanks for taking a look!