### PR TITLE
Fix error saving actor state for readonly changes

### DIFF
--- a/actor/state/state_async_provider.go
+++ b/actor/state/state_async_provider.go
@@ -75,6 +75,11 @@ func (d *DaprStateAsyncProvider) Apply(actorType, actorID string, changes []*Act
 			Value:         value,
 		})
 	}
+
+	if len(operations) == 0 {
+		return nil
+	}
+
 	return d.daprClient.SaveStateTransactionally(context.Background(), actorType, actorID, operations)
 }
 

--- a/actor/state/state_async_provider_test.go
+++ b/actor/state/state_async_provider_test.go
@@ -24,6 +24,35 @@ func TestDaprStateAsyncProvider_Apply(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
+		{
+			name: "empty changes",
+			args: args{
+				actorType: "testActor",
+				actorID:   "test-0",
+				changes:   nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "only readonly state changes",
+			args: args{
+				actorType: "testActor",
+				actorID:   "test-0",
+				changes: []*ActorStateChange{
+					{
+						stateName:  "stateName1",
+						value:      "Any",
+						changeKind: None,
+					},
+					{
+						stateName:  "stateName2",
+						value:      "Any",
+						changeKind: None,
+					},
+				},
+			},
+			wantErr: false,
+		},
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
When there is only readonly state operations (Get, for example), after invoking methods, the state save will error with "actor save state transactionally invocation request param operations is empty" and returns to the user with following error message:

```
rpc error: code = Internal desc = error invoke actor method: rpc error: code = Internal desc = error invoke actor method: error from actor service:
```