### PR TITLE
Expose base grpcclient over client interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -166,6 +166,9 @@ type Client interface {
 
 	// ImplActorClientStub is to impl user defined actor client stub
 	ImplActorClientStub(actorClientStub actor.Client, opt ...config.Option)
+
+	// GrpcClient returns the base grpc client if grpc is used and nil otherwise
+	GrpcClient() pb.DaprClient
 }
 
 // NewClient instantiates Dapr client using DAPR_GRPC_PORT environment variable as port.
@@ -307,4 +310,9 @@ func (c *GRPCClient) Shutdown(ctx context.Context) error {
 		return errors.Wrap(err, "error shutting down the sidecar")
 	}
 	return nil
+}
+
+// GrpcClient returns the base grpc client.
+func (c *GRPCClient) GrpcClient() pb.DaprClient {
+	return c.protoClient
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -415,3 +415,9 @@ func (s *testDaprServer) UnsubscribeConfigurationAlpha1(ctx context.Context, in 
 	delete(s.configurationSubscriptionID, in.Id)
 	return &pb.UnsubscribeConfigurationResponse{Ok: true}, nil
 }
+
+func TestGrpcClient(t *testing.T) {
+	protoClient := pb.NewDaprClient(nil)
+	client := &GRPCClient{protoClient: protoClient}
+	assert.Equal(t, protoClient, client.GrpcClient())
+}


### PR DESCRIPTION
Signed-off-by: Paul Thiele <thielepaul@gmail.com>

Expose GrpcClient so that APIs currently not supported by the SDK (e.g. configuration) can be used with the sdk.

Close #188 
