### PR TITLE
Update golangci-lint-action to v3.1.0

### DIFF
--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -45,6 +45,6 @@ jobs:
       uses: codecov/codecov-action@v1
       
     - name: Lint
-      uses: golangci/golangci-lint-action@v2.2.1
+      uses: golangci/golangci-lint-action@v3.1.0
       with:
         version: ${{ env.GOLANGCILINT_VER }}


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

We currently use golangci/golangci-lint-action's v2.2.1 which installs the latest go version (1.18 in this case). Upgrade to v3.1.0 which reuses the pipeline's go installation.

Related to https://github.com/dapr/components-contrib/issues/1639