### PR TITLE
chore(client): update func definition to be clearer

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -194,7 +194,7 @@ func NewClient() (client Client, err error) {
 	return defaultClient, onceErr
 }
 
-// NewClientWithPort instantiates Dapr using specific port.
+// NewClientWithPort instantiates Dapr using specific gRPC port.
 func NewClientWithPort(port string) (client Client, err error) {
 	if port == "" {
 		return nil, errors.New("nil port")


### PR DESCRIPTION
Started playing around with dapr and had a slight issue as I followed the docs on the main website which suggested running dapr with: `dapr run --app-id myapp --dapr-http-port 3500`. 

When it came to creating the client I assumed I could use `dapr.NewClientWithPort("3500")` but upon further investigation I saw it's internally using a gRPC port. I think we should make it a bit clearer to the reader.