### PR TITLE
Update fossa workflow's action version and trigger branches

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,16 +15,14 @@ name: fossa
 on:
   push:
     branches:
-      - master
+      - main
       - release-*
-      - feature/*
     tags:
       - v*
   pull_request:
     branches:
-      - master
+      - main
       - release-*
-      - feature/*
   workflow_dispatch: {}
 jobs:
   fossa-scan:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -36,12 +36,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Run FOSSA Scan"
-        uses: fossas/fossa-action@main # Use a specific version if locking is preferred
+        uses: fossas/fossa-action@v1.1.0 # Use a specific version if locking is preferred
         with:
           api-key: ${{ env.FOSSA_API_KEY }}
 
       - name: "Run FOSSA Test"
-        uses: fossas/fossa-action@main # Use a specific version if locking is preferred
+        uses: fossas/fossa-action@v1.1.0 # Use a specific version if locking is preferred
         with:
           api-key: ${{ env.FOSSA_API_KEY }}
           run-tests: true


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

1. Due to a recent regression in FOSSA action's main branch, we are moving to the last working version.
1. Update the trigger branches for the FOSSA workflow.

Related to: https://github.com/dapr/dapr/issues/4523