### PR TITLE
fix: client default timeout

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,27 @@ func main() {
 }
 ```
 
+`NewClient` function has a default timeout for 5s, but you can customize this timeout by setting the environment variable `DAPR_CLIENT_TIMEOUT_SECONDS`.  
+For example: 
+```go
+package main
+
+import (
+	"os"
+	
+	dapr "github.com/dapr/go-sdk/client"
+)
+
+func main() {
+    os.Setenv("DAPR_CLIENT_TIMEOUT_SECONDS", "3")
+    client, err := dapr.NewClient()
+    if err != nil {
+        panic(err)
+    }
+    defer client.Close()
+}
+```
+  
 Assuming you have [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr/) installed, you can then launch your app locally like this:
 
 ```shell

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -196,6 +196,40 @@ func getTestClientWithSocket(ctx context.Context) (client Client, closer func())
 	return
 }
 
+func Test_getClientTimeoutSeconds(t *testing.T) {
+	t.Run("empty env var", func(t *testing.T) {
+		os.Setenv(clientTimoutSecondsEnvVarName, "")
+		got, err := getClientTimeoutSeconds()
+		assert.NoError(t, err)
+		assert.Equal(t, clientDefaultTimoutSeconds, got)
+	})
+
+	t.Run("invalid env var", func(t *testing.T) {
+		os.Setenv(clientTimoutSecondsEnvVarName, "invalid")
+		_, err := getClientTimeoutSeconds()
+		assert.Error(t, err)
+	})
+
+	t.Run("normal env var", func(t *testing.T) {
+		os.Setenv(clientTimoutSecondsEnvVarName, "7")
+		got, err := getClientTimeoutSeconds()
+		assert.NoError(t, err)
+		assert.Equal(t, 7, got)
+	})
+
+	t.Run("zero env var", func(t *testing.T) {
+		os.Setenv(clientTimoutSecondsEnvVarName, "0")
+		_, err := getClientTimeoutSeconds()
+		assert.Error(t, err)
+	})
+
+	t.Run("negative env var", func(t *testing.T) {
+		os.Setenv(clientTimoutSecondsEnvVarName, "-3")
+		_, err := getClientTimeoutSeconds()
+		assert.Error(t, err)
+	})
+}
+
 type testDaprServer struct {
 	pb.UnimplementedDaprServer
 	state                             map[string][]byte


### PR DESCRIPTION
Fix for https://github.com/dapr/go-sdk/issues/259

The default timeout is too short and may cause the main container to restart when the sidecar is starting slowly.