### PR TITLE
Fix panic in actor server when invalid methods encountered

### DIFF
--- a/actor/manager/manager.go
+++ b/actor/manager/manager.go
@@ -206,7 +206,7 @@ func suitableMethods(typ reflect.Type) map[string]*MethodType {
 	methods := make(map[string]*MethodType)
 	for m := 0; m < typ.NumMethod(); m++ {
 		method := typ.Method(m)
-		if mt, err := suiteMethod(method); mt != nil && err != nil {
+		if mt, err := suiteMethod(method); err != nil {
 			log.Printf("method %s is illegal, err = %s, just skip it", method.Name, err)
 		} else {
 			methods[method.Name] = mt


### PR DESCRIPTION
I was debugging a panic in a local application I was developing and noticed this issue. A validation failure isn't correctly handled as a failure, and we insert a nil value into the map. This value in this map is later dereferenced, resulting in the following panic:

```
http: panic serving 127.0.0.1:45598: runtime error: invalid memory address or nil pointer dereference
goroutine 248 [running]:
net/http.(*conn).serve.func1()
        /home/linuxbrew/.linuxbrew/Cellar/go/1.19.1/libexec/src/net/http/server.go:1850 +0xbf
panic({0x9558a0, 0xe4d7c0})
        /home/linuxbrew/.linuxbrew/Cellar/go/1.19.1/libexec/src/runtime/panic.go:890 +0x262
github.com/dapr/go-sdk/actor/manager.(*DefaultActorContainer).Invoke(0xc0000be810, {0xc000048126?, 0x9?}, {0xc0003fc000, 0x4, 0x200})
        /home/cgillum/go/pkg/mod/github.com/dapr/go-sdk@v1.5.0/actor/manager/container.go:75 +0x299
github.com/dapr/go-sdk/actor/manager.(*DefaultActorManager).InvokeMethod(0xc000112300, {0xc000048115?, 0xc0000a3888?}, {0xc000048126, 0x4}, {0xc0003fc000, 0x4, 0x200})
        /home/cgillum/go/pkg/mod/github.com/dapr/go-sdk@v1.5.0/actor/manager/manager.go:92 +0xb2
github.com/dapr/go-sdk/actor/runtime.(*ActorRunTime).InvokeActorMethod(0xa?, {0xc00004810c?, 0x7f71edd544a0?}, {0xc000048115, 0x9}, {0xc000048126, 0x4}, {0xc0003fc000, 0x4, 0x200})
        /home/cgillum/go/pkg/mod/github.com/dapr/go-sdk@v1.5.0/actor/runtime/actor_runtime.go:75 +0xba
github.com/dapr/go-sdk/service/http.(*Server).registerBaseHandler.func4({0xad7298, 0xc0003b0000}, 0xc0004e4100)
        /home/cgillum/go/pkg/mod/github.com/dapr/go-sdk@v1.5.0/service/http/topic.go:112 +0x1be
net/http.HandlerFunc.ServeHTTP(0xc0004e4000?, {0xad7298?, 0xc0003b0000?}, 0x800?)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.19.1/libexec/src/net/http/server.go:2109 +0x2f
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000218240, {0xad7298, 0xc0003b0000}, 0xc0003b4600)
        /home/cgillum/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf
net/http.serverHandler.ServeHTTP({0xad62e8?}, {0xad7298, 0xc0003b0000}, 0xc0003b4600)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.19.1/libexec/src/net/http/server.go:2947 +0x30c
net/http.(*conn).serve(0xc0000001e0, {0xad7a00, 0xc00012b380})
        /home/linuxbrew/.linuxbrew/Cellar/go/1.19.1/libexec/src/net/http/server.go:1991 +0x607
created by net/http.(*Server).Serve
        /home/linuxbrew/.linuxbrew/Cellar/go/1.19.1/libexec/src/net/http/server.go:3102 +0x4db
```

The issue appears to be the error handling logic, which I've fixed in this PR.

Signed-off-by: Chris Gillum <cgillum@gmail.com>