### PR TITLE
Add wait() method to block until Sidecar is up.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -53,6 +54,12 @@ var (
 	_             Client = (*GRPCClient)(nil)
 	defaultClient Client
 	doOnce        sync.Once
+)
+
+// The following errors are returned from Wait
+var (
+	// A call to Wait timed out while waiting for a gRPC connection to reach a Ready state.
+	errWaitTimedOut = errors.New("Timed out waiting for client connectivity")
 )
 
 // Client is the interface for Dapr client implementation.
@@ -143,6 +150,9 @@ type Client interface {
 
 	// Shutdown the sidecar.
 	Shutdown(ctx context.Context) error
+
+	// Wait for a  sidecar to become available for at most `timeout` seconds. Returns errWaitTimedOut if timeout is reached.
+	Wait(ctx context.Context, timeout time.Duration) error
 
 	// WithTraceID adds existing trace ID to the outgoing context.
 	WithTraceID(ctx context.Context, id string) context.Context
@@ -341,6 +351,20 @@ func (c *GRPCClient) Shutdown(ctx context.Context) error {
 		return errors.Wrap(err, "error shutting down the sidecar")
 	}
 	return nil
+}
+
+func (c *GRPCClient) Wait(ctx context.Context, timeout time.Duration) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// SDKs for other languages implement Wait by attempting to connect to a TCP endpoint
+	// with a timeout. Go's SDKs handles more endpoints than just TCP ones. To simplify
+	// the code here, we piggy back on GRPCs connectivity state management instead.
+	if c.connection.WaitForStateChange(timeoutCtx, connectivity.Ready) {
+		return nil
+	} else {
+		return errWaitTimedOut
+	}
 }
 
 // GrpcClient returns the base grpc client.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -464,3 +464,26 @@ func TestGrpcClient(t *testing.T) {
 	client := &GRPCClient{protoClient: protoClient}
 	assert.Equal(t, protoClient, client.GrpcClient())
 }
+
+func TestGrpcWait(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Happy Case Client test", func(t *testing.T) {
+		err := testClient.Wait(ctx, 10*time.Second)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Waiting after shutdown fails as there is nothing to wait for", func(t *testing.T) {
+		testClient.Shutdown(ctx)
+		err := testClient.Wait(ctx, 1*time.Second)
+
+		assert.Error(t, err, "Waiting after shutdown should fail as there is no connection left")
+		assert.Equal(t, errWaitTimedOut, err)
+	})
+
+	t.Run("No wait just doesn't work because there is always a delay to accept connections", func(t *testing.T) {
+		err := testClient.Wait(ctx, 0*time.Second)
+		assert.Error(t, err)
+		assert.Equal(t, errWaitTimedOut, err)
+	})
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -464,26 +464,3 @@ func TestGrpcClient(t *testing.T) {
 	client := &GRPCClient{protoClient: protoClient}
 	assert.Equal(t, protoClient, client.GrpcClient())
 }
-
-func TestGrpcWait(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("Happy Case Client test", func(t *testing.T) {
-		err := testClient.Wait(ctx, 10*time.Second)
-		assert.NoError(t, err)
-	})
-
-	t.Run("Waiting after shutdown fails as there is nothing to wait for", func(t *testing.T) {
-		testClient.Shutdown(ctx)
-		err := testClient.Wait(ctx, 1*time.Second)
-
-		assert.Error(t, err, "Waiting after shutdown should fail as there is no connection left")
-		assert.Equal(t, errWaitTimedOut, err)
-	})
-
-	t.Run("No wait just doesn't work because there is always a delay to accept connections", func(t *testing.T) {
-		err := testClient.Wait(ctx, 0*time.Second)
-		assert.Error(t, err)
-		assert.Equal(t, errWaitTimedOut, err)
-	})
-}

--- a/client/wait.go
+++ b/client/wait.go
@@ -33,7 +33,8 @@ func (c *GRPCClient) Wait(ctx context.Context, timeout time.Duration) error {
 
 	// SDKs for other languages implement Wait by attempting to connect to a TCP endpoint
 	// with a timeout. Go's SDKs handles more endpoints than just TCP ones. To simplify
-	// the code here, we piggy back on GRPCs connectivity state management instead.
+	// the code here, we rely on GRPCs connectivity state management instead.
+	// See https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
 	for {
 		curState := c.connection.GetState()
 		if curState == connectivity.Ready {

--- a/client/wait.go
+++ b/client/wait.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"google.golang.org/grpc/connectivity"
+)
+
+// The following errors are returned from Wait
+var (
+	// A call to Wait timed out while waiting for a gRPC connection to reach a Ready state.
+	errWaitTimedOut = errors.New("timed out waiting for client connectivity")
+)
+
+func (c *GRPCClient) Wait(ctx context.Context, timeout time.Duration) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// SDKs for other languages implement Wait by attempting to connect to a TCP endpoint
+	// with a timeout. Go's SDKs handles more endpoints than just TCP ones. To simplify
+	// the code here, we piggy back on GRPCs connectivity state management instead.
+	if c.connection.WaitForStateChange(timeoutCtx, connectivity.Ready) {
+		return nil
+	} else {
+		return errWaitTimedOut
+	}
+}

--- a/client/wait.go
+++ b/client/wait.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
-// The following errors are returned from Wait
+// The following errors are returned from Wait.
 var (
 	// A call to Wait timed out while waiting for a gRPC connection to reach a Ready state.
 	errWaitTimedOut = errors.New("timed out waiting for client connectivity")

--- a/client/wait_test.go
+++ b/client/wait_test.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	unresponsiveServerHost         = "127.0.0.1"
-	unresponsiveTcpPort            = "0" // Port set to 0 so OS auto-selects one
+	unresponsiveTcpPort            = "0" // Port set to 0 so O.S. auto-selects one for us
 	unresponsiveUnixSocketFilePath = "/tmp/unresponsive-server.socket"
 	autoCloseTimeout               = 1 * time.Minute
 )
@@ -38,7 +38,6 @@ func listenButKeepSilent(serverListener net.Listener, serverAddr string) {
 		if err == nil {
 			break
 		} else {
-			// logger.Printf("Server on address %s got a new connection", serverAddr)
 			go func(conn net.Conn) {
 				time.Sleep(autoCloseTimeout)
 				conn.Close()
@@ -48,25 +47,18 @@ func listenButKeepSilent(serverListener net.Listener, serverAddr string) {
 }
 
 func createUnresponsiveTcpServer() (serverAddr string, serverListener net.Listener, err error) {
-	serverAddr = "" // default
-	serverListener, err = net.Listen("tcp", net.JoinHostPort(unresponsiveServerHost, unresponsiveTcpPort))
-	if err != nil {
-		logger.Fatal(err)
-		return "", nil, err
-	}
-
-	serverAddr = serverListener.Addr().String()
-	logger.Println("Created TCP server on address", serverAddr)
-
-	go listenButKeepSilent(serverListener, serverAddr)
-
-	return serverAddr, serverListener, nil
+	return createUnresponsiveServer("tcp", net.JoinHostPort(unresponsiveServerHost, unresponsiveTcpPort))
 }
 
 func createUnresponsiveUnixServer() (serverAddr string, serverListener net.Listener, err error) {
-	serverListener, err = net.Listen("unix", unresponsiveUnixSocketFilePath)
+	return createUnresponsiveServer("unix", unresponsiveUnixSocketFilePath)
+}
+
+func createUnresponsiveServer(network string, unresponsiveServerAddress string) (serverAddr string, serverListener net.Listener, err error) {
+	serverListener, err = net.Listen(network, unresponsiveServerAddress)
 	if err != nil {
-		logger.Fatalf("socket test server created with error: %v", err)
+		logger.Fatalf("Creation of test server on network %s and address %s failed with error: %v",
+			network, unresponsiveServerAddress, err)
 		return "", nil, err
 	}
 

--- a/client/wait_test.go
+++ b/client/wait_test.go
@@ -97,15 +97,10 @@ func TestGrpcWait(t *testing.T) {
 	)
 	ctx := context.Background()
 
-	// // Clean up env. var just in case
-	// os.Setenv(clientTimoutSecondsEnvVarName, "")
-	// _, err := getClientTimeoutSeconds()
-	// assert.NoError(t, err)
-
-	// t.Run("Happy Case Client test", func(t *testing.T) {
-	// 	err := testClient.Wait(ctx, 5*time.Second)
-	// 	assert.NoError(t, err)
-	// })
+	t.Run("Happy Case Client test", func(t *testing.T) {
+		err := testClient.Wait(ctx, waitTimeout)
+		assert.NoError(t, err)
+	})
 
 	t.Run("Non-responding TCP server times out", func(t *testing.T) {
 		serverAddr, serverListener, err := createUnresponsiveTcpServer()
@@ -139,18 +134,4 @@ func TestGrpcWait(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, errWaitTimedOut, err)
 	})
-
-	// t.Run("Waiting after shutdown fails as there is nothing to wait for", func(t *testing.T) {
-	// 	testClient.Shutdown(ctx)
-	// 	err := testClient.Wait(ctx, 5*time.Second)
-
-	// 	assert.Error(t, err, "Waiting after shutdown should fail as there is no connection left")
-	// 	assert.Equal(t, errWaitTimedOut, err)
-	// })
-
-	// t.Run("No wait just doesn't work because there is always a delay to accept connections", func(t *testing.T) {
-	// 	err := testClient.Wait(ctx, 0*time.Second)
-	// 	assert.Error(t, err)
-	// 	assert.Equal(t, errWaitTimedOut, err)
-	// })
 }

--- a/client/wait_test.go
+++ b/client/wait_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrpcWait(t *testing.T) {
+	ctx := context.Background()
+
+	// Clean up env. var just in case
+	os.Setenv(clientTimoutSecondsEnvVarName, "")
+	_, err := getClientTimeoutSeconds()
+	assert.NoError(t, err)
+
+	t.Run("Happy Case Client test", func(t *testing.T) {
+		err := testClient.Wait(ctx, 5*time.Second)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Waiting after shutdown fails as there is nothing to wait for", func(t *testing.T) {
+		testClient.Shutdown(ctx)
+		err := testClient.Wait(ctx, 5*time.Second)
+
+		assert.Error(t, err, "Waiting after shutdown should fail as there is no connection left")
+		assert.Equal(t, errWaitTimedOut, err)
+	})
+
+	t.Run("No wait just doesn't work because there is always a delay to accept connections", func(t *testing.T) {
+		err := testClient.Wait(ctx, 0*time.Second)
+		assert.Error(t, err)
+		assert.Equal(t, errWaitTimedOut, err)
+	})
+}

--- a/client/wait_test.go
+++ b/client/wait_test.go
@@ -100,7 +100,7 @@ func createUnresponsiveServer(network string, unresponsiveServerAddress string) 
 	return server, nil
 }
 
-func createClientConnection(ctx context.Context, serverAddr string) (client Client, err error) {
+func createNonBlockingClient(ctx context.Context, serverAddr string) (client Client, err error) {
 	conn, err := grpc.DialContext(
 		ctx,
 		serverAddr,
@@ -129,7 +129,7 @@ func TestGrpcWaitUnresponsiveTcpServer(t *testing.T) {
 
 	clientConnectionTimeoutCtx, cancel := context.WithTimeout(ctx, connectionTimeout)
 	defer cancel()
-	client, err := createClientConnection(clientConnectionTimeoutCtx, server.address)
+	client, err := createNonBlockingClient(clientConnectionTimeoutCtx, server.address)
 	assert.NoError(t, err)
 
 	err = client.Wait(ctx, waitTimeout)
@@ -147,7 +147,7 @@ func TestGrpcWaitUnresponsiveUnixServer(t *testing.T) {
 
 	clientConnectionTimeoutCtx, cancel := context.WithTimeout(ctx, connectionTimeout)
 	defer cancel()
-	client, err := createClientConnection(clientConnectionTimeoutCtx, "unix://"+server.address)
+	client, err := createNonBlockingClient(clientConnectionTimeoutCtx, "unix://"+server.address)
 	assert.NoError(t, err)
 
 	err = client.Wait(ctx, waitTimeout)

--- a/client/wait_test.go
+++ b/client/wait_test.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	unresponsiveServerHost         = "127.0.0.1"
-	unresponsiveTcpPort            = "0" // Port set to 0 so O.S. auto-selects one for us
+	unresponsiveTCPPort            = "0" // Port set to 0 so O.S. auto-selects one for us
 	unresponsiveUnixSocketFilePath = "/tmp/unresponsive-server.socket"
 
 	waitTimeout       = 5 * time.Second
@@ -72,8 +72,8 @@ func (s *Server) listenButKeepSilent() {
 	}
 }
 
-func createUnresponsiveTcpServer() (*Server, error) {
-	return createUnresponsiveServer("tcp", net.JoinHostPort(unresponsiveServerHost, unresponsiveTcpPort))
+func createUnresponsiveTCPServer() (*Server, error) {
+	return createUnresponsiveServer("tcp", net.JoinHostPort(unresponsiveServerHost, unresponsiveTCPPort))
 }
 
 func createUnresponsiveUnixServer() (*Server, error) {
@@ -123,7 +123,7 @@ func TestGrpcWaitHappyCase(t *testing.T) {
 func TestGrpcWaitUnresponsiveTcpServer(t *testing.T) {
 	ctx := context.Background()
 
-	server, err := createUnresponsiveTcpServer()
+	server, err := createUnresponsiveTCPServer()
 	assert.NoError(t, err)
 	defer server.Close()
 


### PR DESCRIPTION
App might depend on sidecar right away. This PR adds a Wait() method to
enable app to wait for sidecar to be up before invoking the first call.

GRPC client creation on Dapr Go SDK is blocking, so waiting for client
readiness  is less of a problem here than on SDKs where client
connection establishment is async.

Closes #287