### PR TITLE
Allow gRPC options on gRPC server

### DIFF
--- a/service/grpc/service.go
+++ b/service/grpc/service.go
@@ -44,11 +44,11 @@ func NewService(address string) (s common.Service, err error) {
 }
 
 // NewServiceWithListener creates new Service with specific listener.
-func NewServiceWithListener(lis net.Listener) common.Service {
-	return newService(lis)
+func NewServiceWithListener(lis net.Listener, opts ...grpc.ServerOption) common.Service {
+	return newService(lis, opts...)
 }
 
-func newService(lis net.Listener) *Server {
+func newService(lis net.Listener, opts ...grpc.ServerOption) *Server {
 	s := &Server{
 		listener:        lis,
 		invokeHandlers:  make(map[string]common.ServiceInvocationHandler),
@@ -57,7 +57,7 @@ func newService(lis net.Listener) *Server {
 		authToken:       os.Getenv(common.AppAPITokenEnvVar),
 	}
 
-	gs := grpc.NewServer()
+	gs := grpc.NewServer(opts...)
 	pb.RegisterAppCallbackServer(gs, s)
 	pb.RegisterAppCallbackHealthCheckServer(gs, s)
 	s.grpcServer = gs


### PR DESCRIPTION
Currently the gRPC server is created within the `newService` call which does not support passing gRPC server options. This change adds an additional "optional" 
parameter that is the gRPC server options that will be passed to the grpc server ctor.

Signed-off-by: Joni Collinge <jonathancollinge@live.com>
