### PR TITLE
[docs] Add cryptography examples

### DIFF
--- a/daprdocs/content/en/go-sdk-docs/go-client/_index.md
+++ b/daprdocs/content/en/go-sdk-docs/go-client/_index.md
@@ -145,10 +145,6 @@ err := testClient.ExecuteStateTransaction(ctx, store, meta, ops)
 For a full guide on state management, visit [How-To: Save & get state]({{< ref howto-get-save-state.md >}}).
 
 
-### Query state
-
-
-
 ### Publish Messages
 To publish data onto a topic, the Dapr Go client provides a simple method:
 
@@ -187,7 +183,6 @@ out, err := client.InvokeBinding(ctx, in)
 
 For a full guide on output bindings, visit [How-To: Use bindings]({{< ref howto-bindings.md >}}).
 
-### Actors
 
 ### Secret Management
 
@@ -293,6 +288,36 @@ go func() {
 
 For a full guide on configuration, visit [How-To: Manage configuration from a store]({{< ref howto-manage-configuration.md >}}).
 
+### Cryptography
+
+With the Dapr client Go SDK, you can use the high-level `Encrypt` and `Decrypt` cryptography APIs to encrypt and decrypt files while working on a stream of data.
+
+To encrypt:
+
+```go
+// Encrypt the data using Dapr
+out, err := sdkClient.Encrypt(context.Background(), rf, dapr.EncryptOptions{
+	// These are the 3 required parameters
+	ComponentName: "mycryptocomponent",
+	KeyName:        "mykey",
+	Algorithm:     "RSA",
+})
+if err != nil {
+	panic(err)
+}
+```
+
+To decrypt:
+
+```go
+// Decrypt the data using Dapr
+out, err := sdkClient.Decrypt(context.Background(), rf, dapr.EncryptOptions{
+	// Only required option is the component name
+	ComponentName: "mycryptocomponent",
+})
+```
+
+For a full guide on cryptography, visit [How-To: Use the cryptography APIs]({{< ref howto-cryptography.md >}}).
 
 ## Related links
 [Go SDK Examples](https://github.com/dapr/go-sdk/tree/main/examples)


### PR DESCRIPTION
Add `encrypt` and `decrypt` examples to the go client doc
Remove empty headers that still need examples someday :)