### PR TITLE
Allow setting own gRPC server when calling `NewService`

### DIFF
--- a/service/grpc/service.go
+++ b/service/grpc/service.go
@@ -39,16 +39,21 @@ func NewService(address string) (s common.Service, err error) {
 		err = fmt.Errorf("failed to TCP listen on %s: %w", address, err)
 		return
 	}
-	s = newService(lis)
+	s = newService(lis, nil)
 	return
 }
 
 // NewServiceWithListener creates new Service with specific listener.
 func NewServiceWithListener(lis net.Listener, opts ...grpc.ServerOption) common.Service {
-	return newService(lis, opts...)
+	return newService(lis, nil, opts...)
 }
 
-func newService(lis net.Listener, opts ...grpc.ServerOption) *Server {
+// NewServiceWithGrpcServer creates a new Service with specific listener and grpcServer
+func NewServiceWithGrpcServer(lis net.Listener, server *grpc.Server) common.Service {
+	return newService(lis, server)
+}
+
+func newService(lis net.Listener, grpcServer *grpc.Server, opts ...grpc.ServerOption) *Server {
 	s := &Server{
 		listener:        lis,
 		invokeHandlers:  make(map[string]common.ServiceInvocationHandler),
@@ -57,7 +62,14 @@ func newService(lis net.Listener, opts ...grpc.ServerOption) *Server {
 		authToken:       os.Getenv(common.AppAPITokenEnvVar),
 	}
 
-	gs := grpc.NewServer(opts...)
+	var gs *grpc.Server
+
+	if grpcServer != nil {
+		gs = grpcServer
+	} else {
+		gs = grpc.NewServer(opts...)
+	}
+
 	pb.RegisterAppCallbackServer(gs, s)
 	pb.RegisterAppCallbackHealthCheckServer(gs, s)
 	s.grpcServer = gs

--- a/service/grpc/service.go
+++ b/service/grpc/service.go
@@ -62,17 +62,13 @@ func newService(lis net.Listener, grpcServer *grpc.Server, opts ...grpc.ServerOp
 		authToken:       os.Getenv(common.AppAPITokenEnvVar),
 	}
 
-	var gs *grpc.Server
-
-	if grpcServer != nil {
-		gs = grpcServer
-	} else {
-		gs = grpc.NewServer(opts...)
+	if grpcServer == nil {
+		grpcServer = grpc.NewServer(opts...)
 	}
 
-	pb.RegisterAppCallbackServer(gs, s)
-	pb.RegisterAppCallbackHealthCheckServer(gs, s)
-	s.grpcServer = gs
+	pb.RegisterAppCallbackServer(grpcServer, s)
+	pb.RegisterAppCallbackHealthCheckServer(grpcServer, s)
+	s.grpcServer = grpcServer
 
 	return s
 }

--- a/service/grpc/service_test.go
+++ b/service/grpc/service_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -31,13 +32,19 @@ func TestServerWithListener(t *testing.T) {
 	assert.NotNil(t, server)
 }
 
+func TestServerWithGrpcServer(t *testing.T) {
+	grpcServer := grpc.NewServer()
+	server := NewServiceWithGrpcServer(bufconn.Listen(1024*1024), grpcServer)
+	assert.NotNil(t, server)
+}
+
 func TestService(t *testing.T) {
 	_, err := NewService("")
 	assert.Errorf(t, err, "expected error from lack of address")
 }
 
 func getTestServer() *Server {
-	return newService(bufconn.Listen(1024 * 1024))
+	return newService(bufconn.Listen(1024*1024), nil)
 }
 
 func startTestServer(server *Server) {


### PR DESCRIPTION
We are building an application that exposes it's own gRPC service, it also needs to subscribe to the dapr pub/sub component.

Currently we are allowed to set the listener, but this is not enough, as we found that about half of the time, our own gRPC server responds, and the other half of the time the dapr service responds with an `unknown service xxx.xxx`.

If this is merged, the user is allowed to set their own grpcServer with the `NewServiceWithGrpcServer()` func.


In action:
```golang
lis, _ := net.Listen("tcp", "localhost:8080")
server := grpc.NewServer()

// Register dapr
dapr.NewServiceWithGrpcServer(lis, server)

// Setup dapr subscriptions here

// Register own services
proto.RegisterOwnServer1(server, ownServer1{})
proto.RegisterOwnServer2(server, ownServer2{})

go server.Serve(lis)
```


In issue https://github.com/dapr/go-sdk/issues/237 the same problem has been found.
