### PR TITLE
Add note about Actor State `WithTTL` being feature preview.

### DIFF
--- a/actor/actor.go
+++ b/actor/actor.go
@@ -207,13 +207,12 @@ type StateManagerContext interface {
 	// Get is to get state store of @stateName with type @reply
 	Get(ctx context.Context, stateName string, reply any) error
 	// Set sets a state store with @stateName and @value.
-	// You should always use SetWithTTL unless you also intend to implement your
-	// own state expiration logic. This is to prevent the state store from
-	// growing indefinitely.
 	Set(ctx context.Context, stateName string, value any) error
 	// SetWithTTL sets a state store with @stateName and @value, for the given
 	// TTL. After the TTL has passed, the value will no longer be available with
 	// `Get`. Always preferred over `Set`.
+	// NOTE: SetWithTTL is in feature preview as of v1.11, and only available
+	// with the `ActorStateTTL` feature enabled in Dapr.
 	SetWithTTL(ctx context.Context, stateName string, value any, ttl time.Duration) error
 	// Remove is to remove state store with @stateName
 	Remove(ctx context.Context, stateName string) error

--- a/examples/actor/serving/main.go
+++ b/examples/actor/serving/main.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"time"
 
 	"github.com/dapr/go-sdk/actor"
 	dapr "github.com/dapr/go-sdk/client"
@@ -117,10 +116,7 @@ func (t *TestActor) IncrementAndGet(ctx context.Context, stateKey string) (*api.
 		}
 	}
 	stateData.Age++
-	// You should always use `SetWithTTL` to set state with expiration time
-	// unless you also implement cleanup logic. This prevents the state store
-	// from growing indefinitely.
-	if err := t.GetStateManager().SetWithTTL(ctx, stateKey, stateData, time.Minute); err != nil {
+	if err := t.GetStateManager().Set(ctx, stateKey, stateData); err != nil {
 		fmt.Printf("state manager set get with key %s and state data = %+v, error = %s", stateKey, stateData, err.Error())
 		return &stateData, err
 	}


### PR DESCRIPTION
Due to the nature of the current implementation of write through caching of actor state and the unavailability of the real TTL expire time of state keys, SDKs will have an inconsistent view of the world when it has a cold cache and the state store has TTL keys. The TTL functionality has been put behind a feature gate in daprd. See [dapr/dapr](https://github.com/dapr/dapr/pull/6400) for more details.

PR updates the SDK comments to reflect this.]

/cc @artursouza @yaron2 