### PR TITLE
Ensure that calling grpcServer.Stop() only once

### DIFF
--- a/service/grpc/service.go
+++ b/service/grpc/service.go
@@ -85,6 +85,7 @@ type Server struct {
 	authToken          string
 	grpcServer         *grpc.Server
 	started            uint32
+	stopped            uint32
 }
 
 // Deprecated: Use RegisterActorImplFactoryContext instead.
@@ -101,26 +102,37 @@ func (s *Server) Start() error {
 	if !atomic.CompareAndSwapUint32(&s.started, 0, 1) {
 		return errors.New("a gRPC server can only be started once")
 	}
+
+	if atomic.LoadUint32(&s.stopped) == 1 {
+		return errors.New("the gRPC server has stopped")
+	}
+
 	return s.grpcServer.Serve(s.listener)
 }
 
 // Stop stops the previously-started service.
 func (s *Server) Stop() error {
-	if atomic.LoadUint32(&s.started) == 0 {
-		return nil
-	}
-	s.grpcServer.Stop()
-	s.grpcServer = nil
-	return nil
+	return s.gracefulStop(false)
 }
 
 // GrecefulStop stops the previously-started service gracefully.
 func (s *Server) GracefulStop() error {
+	return s.gracefulStop(true)
+}
+
+func (s *Server) gracefulStop(graceful bool) error {
 	if atomic.LoadUint32(&s.started) == 0 {
 		return nil
 	}
-	s.grpcServer.GracefulStop()
-	s.grpcServer = nil
+
+	if atomic.CompareAndSwapUint32(&s.stopped, 0, 1) {
+		if graceful {
+			s.grpcServer.GracefulStop()
+		} else {
+			s.grpcServer.Stop()
+		}
+		s.grpcServer = nil
+	}
 	return nil
 }
 

--- a/service/grpc/service_test.go
+++ b/service/grpc/service_test.go
@@ -64,3 +64,42 @@ func stopTestServer(t *testing.T, server *Server) {
 	err := server.Stop()
 	assert.Nilf(t, err, "error stopping server")
 }
+
+func TestStartServerTimes(t *testing.T) {
+	server := getTestServer()
+
+	startTestServer(server)
+	assert.PanicsWithError(t, "a gRPC server can only be started once", func() {
+		if err := server.Start(); err != nil && err.Error() != "closed" {
+			panic(err)
+		}
+	})
+
+	time.Sleep(time.Second)
+
+	stopTestServer(t, server)
+}
+
+func TestStopServerTimes(t *testing.T) {
+	server := getTestServer()
+	startTestServer(server)
+
+	err := server.Stop()
+	assert.Nilf(t, err, "error stopping server")
+
+	err = server.Stop()
+	assert.Nilf(t, err, "error stopping server")
+}
+
+func TestStopServerBeforeStart(t *testing.T) {
+	server := getTestServer()
+	stopTestServer(t, server)
+}
+
+func TestStartServerAfterStop(t *testing.T) {
+	server := getTestServer()
+	startTestServer(server)
+	stopTestServer(t, server)
+	err := server.Start()
+	assert.NotNil(t, err)
+}

--- a/service/grpc/service_test.go
+++ b/service/grpc/service_test.go
@@ -15,6 +15,7 @@ package grpc
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -53,6 +54,7 @@ func startTestServer(server *Server) {
 			panic(err)
 		}
 	}()
+	time.Sleep(time.Second)
 }
 
 func stopTestServer(t *testing.T, server *Server) {


### PR DESCRIPTION
https://github.com/dapr/go-sdk/issues/411