### PR TITLE
Fixed: do not require a Content-Length header

### DIFF
--- a/service/http/binding.go
+++ b/service/http/binding.go
@@ -37,14 +37,16 @@ func (s *Server) AddBindingInvocationHandler(route string, fn common.BindingInvo
 
 	s.mux.Handle(route, optionsHandler(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			var content []byte
-			if r.ContentLength > 0 {
-				body, err := io.ReadAll(r.Body)
+			var (
+				content []byte
+				err     error
+			)
+			if r.Body != nil {
+				content, err = io.ReadAll(r.Body)
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
-				content = body
 			}
 
 			// assuming Dapr doesn't pass multiple values for key

--- a/service/http/invoke.go
+++ b/service/http/invoke.go
@@ -54,14 +54,13 @@ func (s *Server) AddServiceInvocationHandler(route string, fn common.ServiceInvo
 				ContentType: r.Header.Get("Content-type"),
 			}
 
-			// check for post with no data
-			if r.ContentLength > 0 {
-				content, err := io.ReadAll(r.Body)
+			var err error
+			if r.Body != nil {
+				e.Data, err = io.ReadAll(r.Body)
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
-				e.Data = content
 			}
 
 			ctx := r.Context()

--- a/service/http/topic.go
+++ b/service/http/topic.go
@@ -67,7 +67,7 @@ type topicEventJSON struct {
 	PubsubName string `json:"pubsubname"`
 }
 
-func (in topicEventJSON) GetData() (data any, rawData []byte) {
+func (in topicEventJSON) getData() (data any, rawData []byte) {
 	var (
 		err error
 		v   any
@@ -265,7 +265,7 @@ func (s *Server) AddTopicEventHandler(sub *common.Subscription, fn common.TopicE
 				in.Topic = sub.Topic
 			}
 
-			data, rawData := in.GetData()
+			data, rawData := in.getData()
 			te := common.TopicEvent{
 				ID:              in.ID,
 				SpecVersion:     in.SpecVersion,

--- a/service/http/topic_test.go
+++ b/service/http/topic_test.go
@@ -25,12 +25,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dapr/go-sdk/actor/api"
-	"github.com/dapr/go-sdk/actor/mock"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dapr/go-sdk/actor/api"
+	"github.com/dapr/go-sdk/actor/mock"
 	"github.com/dapr/go-sdk/service/common"
 	"github.com/dapr/go-sdk/service/internal"
 )


### PR DESCRIPTION
The HTTP service in multiple places expected a Content-Length header or it would refuse to parse the body.

This breaks streaming (see [test failures](https://github.com/dapr/dapr/actions/runs/5446419269/jobs/9907127023)), since in case the data is streamed it's not possible to know the content's byte length in advance. The Content-Length header is not required per the HTTP specs, so we should not enforce its presence.

This fixes the issue by not relying on the Content-Length header's presence.