### PR TITLE
add go 1.21 to gh actions workflow test

### DIFF
--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -17,6 +17,7 @@ jobs:
         gover:
           - "1.19"
           - "1.20"
+          - "1.21"
     env:
       GOVER: ${{ matrix.gover }}
       GOLANGCILINT_VER: v1.52.2


### PR DESCRIPTION
This adds the new 1.21 release. I've already bumped and it's running fine.

Signed-off-by: mikeee <hey@mike.ee>