### PR TITLE
fix: rm superfluous header on actor example

### DIFF
--- a/service/http/topic.go
+++ b/service/http/topic.go
@@ -196,7 +196,6 @@ func (s *Server) registerBaseHandler() {
 		if err != actorErr.Success {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		w.WriteHeader(http.StatusOK)
 	}
 	s.mux.Put("/actors/{actorType}/{actorId}/method/remind/{reminderName}", fReminder)
 


### PR DESCRIPTION
Similar to:
https://github.com/dapr/go-sdk/issues/218

There is a superfluous header call show in the actors example:
```
al.placement type=log ver=edge
DEBU[0004] Executing reminder for actor testActorType||ActorImplID123456||testReminderName  app_id=actor-serving instance=Samanthas-MacBook-Pro-2.local scope=dapr.runtime.actor type=log ver=edge
== APP == 2023/09/08 14:15:37 failed to unmarshal reminder param, err: illegal base64 data at input byte 4 
== APP == 2023/09/08 14:15:37 http: superfluous response.WriteHeader call from github.com/dapr/go-sdk/service/http.(*Server).registerBaseHandler.func6 (topic.go:199)
```

With the removal of the line in this PR, the superflous header is removed:
```
DEBU[0002] Executing reminder for actor testActorType||ActorImplID123456||testReminderName  app_id=actor-serving instance=Samanthas-MacBook-Pro-2.local scope=dapr.runtime.actor type=log ver=edge
== APP == 2023/09/08 14:16:24 failed to unmarshal reminder param, err: illegal base64 data at input byte 4 
```