### PR TITLE
add note on unsubscribeConfiguration being deprecated

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -142,8 +142,8 @@ type Client interface {
 	// SubscribeConfigurationItems can subscribe the change of configuration items by storeName and keys, and return subscription id
 	SubscribeConfigurationItems(ctx context.Context, storeName string, keys []string, handler ConfigurationHandleFunction, opts ...ConfigurationOpt) (string, error)
 
-	// This function calls UnsubscribeConfiguration which is deprecated and exists for backwards-compatibility only
-	// The unsubscribe occurs when closing the subscription stream
+	// UnsubscribeConfigurationItems stops the subscription with target store's and ID.
+	// Deprecated: Closing the `SubscribeConfigurationItems` stream (closing the given context) will unsubscribe the client and should be used in favor of `UnsubscribeConfigurationItems`.
 	// UnsubscribeConfigurationItems can stop the subscription with target store's and id
 	UnsubscribeConfigurationItems(ctx context.Context, storeName string, id string, opts ...ConfigurationOpt) error
 

--- a/client/client.go
+++ b/client/client.go
@@ -142,6 +142,8 @@ type Client interface {
 	// SubscribeConfigurationItems can subscribe the change of configuration items by storeName and keys, and return subscription id
 	SubscribeConfigurationItems(ctx context.Context, storeName string, keys []string, handler ConfigurationHandleFunction, opts ...ConfigurationOpt) (string, error)
 
+	// This function calls UnsubscribeConfiguration which is deprecated and exists for backwards-compatibility only
+	// The unsubscribe occurs when closing the subscription stream
 	// UnsubscribeConfigurationItems can stop the subscription with target store's and id
 	UnsubscribeConfigurationItems(ctx context.Context, storeName string, id string, opts ...ConfigurationOpt) error
 


### PR DESCRIPTION
Explicitly noting a deprecated function to make it more obvious to end users. Suggestions to wording it differently are welcomed.