### PR TITLE
fix: fix broken dapr setup links

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -23,7 +23,8 @@ This quickstart requires you to have the following installed on your machine:
 
 ## Step 1 - Setup Dapr
 
-Follow [instructions](https://docs.dapr.io/getting-started/install-dapr/) to download and install the Dapr CLI and initialize Dapr.
+- [Install the Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
+- [Initialise Dapr Locally](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 
 ## Step 2 - Understand the code
 

--- a/examples/socket/README.md
+++ b/examples/socket/README.md
@@ -12,7 +12,8 @@ This quickstart requires you to have the following installed on your machine:
 
 ## Step 1 - Setup Dapr
 
-Follow [instructions](https://docs.dapr.io/getting-started/install-dapr/) to download and install the Dapr CLI and initialize Dapr.
+- [Install the Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
+- [Initialise Dapr Locally](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 
 ## Step 2 - Understand the code
 


### PR DESCRIPTION
Replace the dapr getting-started link with two steps to install the cli and initialise dapr locally.