### PR TITLE
fix: update StateConsistency type to match protobufs

### DIFF
--- a/client/state.go
+++ b/client/state.go
@@ -46,6 +46,19 @@ const (
 	StateOperationTypeUpsert OperationType = 1
 	// StateOperationTypeDelete represents delete operation type value.
 	StateOperationTypeDelete OperationType = 2
+
+	// EventualType represents the eventual type value.
+	EventualType = "eventual"
+	// StrongType represents the strong type value.
+	StrongType = "strong"
+	// FirstWriteType represents the first write type value.
+	FirstWriteType = "first-write"
+	// LastWriteType represents the last write type value.
+	LastWriteType = "last-write"
+	// UpsertType represents the upsert type value.
+	UpsertType = "upsert"
+	// DeleteType represents the delete type value.
+	DeleteType = "delete"
 	// UndefinedType represents undefined type value.
 	UndefinedType = "undefined"
 )
@@ -73,8 +86,8 @@ func (s StateConcurrency) GetPBConcurrency() v1.StateOptions_StateConcurrency {
 func (o OperationType) String() string {
 	names := [...]string{
 		UndefinedType,
-		"upsert",
-		"delete",
+		UpsertType,
+		DeleteType,
 	}
 	if o < StateOperationTypeUpsert || o > StateOperationTypeDelete {
 		return UndefinedType
@@ -87,8 +100,8 @@ func (o OperationType) String() string {
 func (s StateConsistency) String() string {
 	names := [...]string{
 		UndefinedType,
-		"eventual",
-		"strong",
+		EventualType,
+		StrongType,
 	}
 	if s < StateConsistencyEventual || s > StateConsistencyStrong {
 		return UndefinedType
@@ -101,8 +114,8 @@ func (s StateConsistency) String() string {
 func (s StateConcurrency) String() string {
 	names := [...]string{
 		UndefinedType,
-		"first-write",
-		"last-write",
+		FirstWriteType,
+		LastWriteType,
 	}
 	if s < StateConcurrencyFirstWrite || s > StateConcurrencyLastWrite {
 		return UndefinedType

--- a/client/state_test.go
+++ b/client/state_test.go
@@ -34,18 +34,24 @@ func TestTypes(t *testing.T) {
 	t.Run("test operation types", func(t *testing.T) {
 		var a OperationType = -1
 		assert.Equal(t, UndefinedType, a.String())
+		a = 1
+		assert.Equal(t, UpsertType, a.String())
 		a = 2
 		assert.Equal(t, DeleteType, a.String())
 	})
 	t.Run("test state concurrency type", func(t *testing.T) {
 		var b StateConcurrency = -1
 		assert.Equal(t, UndefinedType, b.String())
+		b = 1
+		assert.Equal(t, FirstWriteType, b.String())
 		b = 2
 		assert.Equal(t, LastWriteType, b.String())
 	})
 	t.Run("test state consistency type", func(t *testing.T) {
 		var c StateConsistency = -1
 		assert.Equal(t, UndefinedType, c.String())
+		c = 1
+		assert.Equal(t, EventualType, c.String())
 		c = 2
 		assert.Equal(t, StrongType, c.String())
 	})

--- a/client/state_test.go
+++ b/client/state_test.go
@@ -35,19 +35,19 @@ func TestTypes(t *testing.T) {
 		var a OperationType = -1
 		assert.Equal(t, UndefinedType, a.String())
 		a = 2
-		assert.Equal(t, "delete", a.String())
+		assert.Equal(t, DeleteType, a.String())
 	})
 	t.Run("test state concurrency type", func(t *testing.T) {
 		var b StateConcurrency = -1
 		assert.Equal(t, UndefinedType, b.String())
 		b = 2
-		assert.Equal(t, "last-write", b.String())
+		assert.Equal(t, LastWriteType, b.String())
 	})
 	t.Run("test state consistency type", func(t *testing.T) {
 		var c StateConsistency = -1
 		assert.Equal(t, UndefinedType, c.String())
 		c = 2
-		assert.Equal(t, "strong", c.String())
+		assert.Equal(t, StrongType, c.String())
 	})
 }
 


### PR DESCRIPTION
Fixes StateConsistency type to match protobufs, at the moment returns undefined for everything due to the logic.

https://github.com/dapr/dapr/blob/ed3417223c5ea4654f38df1fc5abee93e52cea6e/dapr/proto/common/v1/common.proto#L140