### PR TITLE
perf: enhanced configuration example

### DIFF
--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -22,7 +22,7 @@ expected_stdout_lines:
   - '== APP == got config key = mySubscribeKey3, value = mySubscribeValue2'
   - '== APP == got config key = mySubscribeKey1, value = mySubscribeValue3'
   - '== APP == got config key = mySubscribeKey2, value = mySubscribeValue3'
-  - '== APP == get config key = mySubscribeKey3, value = mySubscribeValue3'
+  - '== APP == got config key = mySubscribeKey3, value = mySubscribeValue3'
   - '== APP == dapr configuration subscribe finished.'
 background: false
 sleep: 40

--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -13,16 +13,16 @@ name: Run Configuration Client
 output_match_mode: substring
 match_order: none
 expected_stdout_lines:
-  - '== APP == get config = myConfigValue'
-  - '== APP == get updated config key = mySubscribeKey1, value = mySubscribeValue1'
-  - '== APP == get updated config key = mySubscribeKey2, value = mySubscribeValue1'
-  - '== APP == get updated config key = mySubscribeKey3, value = mySubscribeValue1'
-  - '== APP == get updated config key = mySubscribeKey1, value = mySubscribeValue2'
-  - '== APP == get updated config key = mySubscribeKey2, value = mySubscribeValue2'
-  - '== APP == get updated config key = mySubscribeKey3, value = mySubscribeValue2'
-  - '== APP == get updated config key = mySubscribeKey1, value = mySubscribeValue3'
-  - '== APP == get updated config key = mySubscribeKey2, value = mySubscribeValue3'
-  - '== APP == get updated config key = mySubscribeKey3, value = mySubscribeValue3'
+  - '== APP == got config key = mykey, value = myConfigValue'
+  - '== APP == got config key = mySubscribeKey1, value = mySubscribeValue1'
+  - '== APP == got config key = mySubscribeKey2, value = mySubscribeValue1'
+  - '== APP == got config key = mySubscribeKey3, value = mySubscribeValue1'
+  - '== APP == got config key = mySubscribeKey1, value = mySubscribeValue2'
+  - '== APP == got config key = mySubscribeKey2, value = mySubscribeValue2'
+  - '== APP == got config key = mySubscribeKey3, value = mySubscribeValue2'
+  - '== APP == got config key = mySubscribeKey1, value = mySubscribeValue3'
+  - '== APP == got config key = mySubscribeKey2, value = mySubscribeValue3'
+  - '== APP == get config key = mySubscribeKey3, value = mySubscribeValue3'
   - '== APP == dapr configuration subscribe finished.'
 background: false
 sleep: 40
@@ -47,23 +47,23 @@ dapr run --app-id configuration-api\
 The subscription event order may out of order.
 
 ```
-got config key = mykey, with value = myConfigValue
+got config key = mykey, value = myConfigValue
 
-got config key = mySubscribeKey1, with value = mySubscribeValue1 
-got config key = mySubscribeKey2, with value = mySubscribeValue1 
-got config key = mySubscribeKey3, with value = mySubscribeValue1 
-got config key = mySubscribeKey1, with value = mySubscribeValue2 
-got config key = mySubscribeKey2, with value = mySubscribeValue2 
-got config key = mySubscribeKey3, with value = mySubscribeValue2 
-got config key = mySubscribeKey1, with value = mySubscribeValue3 
-got config key = mySubscribeKey2, with value = mySubscribeValue3 
-got config key = mySubscribeKey3, with value = mySubscribeValue3 
-got config key = mySubscribeKey1, with value = mySubscribeValue4 
-got config key = mySubscribeKey2, with value = mySubscribeValue4 
-got config key = mySubscribeKey3, with value = mySubscribeValue4 
-got config key = mySubscribeKey1, with value = mySubscribeValue5 
-got config key = mySubscribeKey2, with value = mySubscribeValue5 
-got config key = mySubscribeKey3, with value = mySubscribeValue5 
+got config key = mySubscribeKey1, value = mySubscribeValue1 
+got config key = mySubscribeKey2, value = mySubscribeValue1 
+got config key = mySubscribeKey3, value = mySubscribeValue1 
+got config key = mySubscribeKey1, value = mySubscribeValue2 
+got config key = mySubscribeKey2, value = mySubscribeValue2 
+got config key = mySubscribeKey3, value = mySubscribeValue2 
+got config key = mySubscribeKey1, value = mySubscribeValue3 
+got config key = mySubscribeKey2, value = mySubscribeValue3 
+got config key = mySubscribeKey3, value = mySubscribeValue3 
+got config key = mySubscribeKey1, value = mySubscribeValue4 
+got config key = mySubscribeKey2, value = mySubscribeValue4 
+got config key = mySubscribeKey3, value = mySubscribeValue4 
+got config key = mySubscribeKey1, value = mySubscribeValue5 
+got config key = mySubscribeKey2, value = mySubscribeValue5 
+got config key = mySubscribeKey3, value = mySubscribeValue5 
 dapr configuration subscribe finished.
 dapr configuration unsubscribed
 ✅  Exited App successfully

--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -47,17 +47,25 @@ dapr run --app-id configuration-api\
 The subscription event order may out of order.
 
 ```
-get config = myConfigValue
-get updated config key = mySubscribeKey1, value = mySubscribeValue1 
-get updated config key = mySubscribeKey2, value = mySubscribeValue1 
-get updated config key = mySubscribeKey3, value = mySubscribeValue1 
-get updated config key = mySubscribeKey1, value = mySubscribeValue2 
-get updated config key = mySubscribeKey2, value = mySubscribeValue2 
-get updated config key = mySubscribeKey3, value = mySubscribeValue2 
-get updated config key = mySubscribeKey1, value = mySubscribeValue3 
-get updated config key = mySubscribeKey2, value = mySubscribeValue3 
-get updated config key = mySubscribeKey3, value = mySubscribeValue3 
+got config key = mykey, with value = myConfigValue
+
+got config key = mySubscribeKey1, with value = mySubscribeValue1 
+got config key = mySubscribeKey2, with value = mySubscribeValue1 
+got config key = mySubscribeKey3, with value = mySubscribeValue1 
+got config key = mySubscribeKey1, with value = mySubscribeValue2 
+got config key = mySubscribeKey2, with value = mySubscribeValue2 
+got config key = mySubscribeKey3, with value = mySubscribeValue2 
+got config key = mySubscribeKey1, with value = mySubscribeValue3 
+got config key = mySubscribeKey2, with value = mySubscribeValue3 
+got config key = mySubscribeKey3, with value = mySubscribeValue3 
+got config key = mySubscribeKey1, with value = mySubscribeValue4 
+got config key = mySubscribeKey2, with value = mySubscribeValue4 
+got config key = mySubscribeKey3, with value = mySubscribeValue4 
+got config key = mySubscribeKey1, with value = mySubscribeValue5 
+got config key = mySubscribeKey2, with value = mySubscribeValue5 
+got config key = mySubscribeKey3, with value = mySubscribeValue5 
 dapr configuration subscribe finished.
+dapr configuration unsubscribed
 ✅  Exited App successfully
 
 ```

--- a/examples/configuration/main.go
+++ b/examples/configuration/main.go
@@ -20,7 +20,7 @@ func addItems(wg *sync.WaitGroup) {
 	// set config value
 	client.Set(context.Background(), "mykey", "myConfigValue", -1)
 	ticker := time.NewTicker(time.Second)
-	wg.Add(3*5)
+	wg.Add(3 * 5)
 	go func() {
 		for i := 0; i < 5; i++ {
 			<-ticker.C
@@ -46,7 +46,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("got config key = mykey, with value = %s \n", (*items).Value)
+	fmt.Printf("got config key = mykey, value = %s \n", (*items).Value)
 
 	ctx, f := context.WithTimeout(ctx, 60*time.Second)
 	md := metadata.Pairs("dapr-app-id", "configuration-api")
@@ -55,7 +55,7 @@ func main() {
 	subscribeID, err := client.SubscribeConfigurationItems(ctx, "example-config", []string{"mySubscribeKey1", "mySubscribeKey2", "mySubscribeKey3"}, func(id string, items map[string]*dapr.ConfigurationItem) {
 		wg.Done()
 		for k, v := range items {
-			fmt.Printf("got config key = %s, with value = %s \n", k, v.Value)
+			fmt.Printf("got config key = %s, value = %s \n", k, v.Value)
 		}
 	})
 	if err != nil {

--- a/examples/configuration/main.go
+++ b/examples/configuration/main.go
@@ -24,7 +24,6 @@ func addItems(wg *sync.WaitGroup) {
 	go func() {
 		for i := 0; i < 5; i++ {
 			<-ticker.C
-			// update config value
 			client.Set(context.Background(), "mySubscribeKey1", "mySubscribeValue"+strconv.Itoa(i+1), -1)
 			client.Set(context.Background(), "mySubscribeKey2", "mySubscribeValue"+strconv.Itoa(i+1), -1)
 			client.Set(context.Background(), "mySubscribeKey3", "mySubscribeValue"+strconv.Itoa(i+1), -1)


### PR DESCRIPTION
Eliminated ```time.sleep``` with ```sync.WaitGroup``` so ```SubscribeConfigurationItems``` can take proper time to finish and also updated to more appropriate logs