### PR TITLE
fix: Overhaul the validation action

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -20,7 +20,7 @@ jobs:
       GOPROXY: https://proxy.golang.org
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
       DAPR_CLI_REF: ""
-      DAPR_REF: 770d4e51604f1264d8bb25cedf16ea9f77539394
+      DAPR_REF: ""
     steps:
       - uses: actions/checkout@v3
       - name: Determine latest Dapr Runtime version

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -146,16 +146,27 @@ jobs:
       DAPR_RUNTIME_VER: ${{ needs.setup.outputs.DAPR_RUNTIME_VER }}
       DAPR_CLI_REF: ${{ github.event.inputs.daprcli_commit }}
       DAPR_REF: ${{ github.event.inputs.daprdapr_commit }}
+      CHECKOUT_REPO: ${{ needs.setup.outputs.CHECKOUT_REPO }}
+      CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
+
 
     strategy:
       matrix:
         examples: [ "actor", "configuation", "grpc-service", "hello-world", "pubsub", "service", "socket" ]
     steps:
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CHECKOUT_REPO }}
+          ref: ${{ env.CHECKOUT_REF }}
+
       - name: Make Artifacts destination folder
+        if: env.DAPR_CLI_REF != '' || env.DAPR_REF != ''
         run: |
           mkdir -p $HOME/artifacts/$GITHUB_SHA/
 
       - name: Retrieve dapr-artifacts
+        if: env.DAPR_CLI_REF != '' || env.DAPR_REF != ''
         uses: actions/download-artifact@v4
         with:
           name: dapr-artifacts

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -27,14 +27,21 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     env:
-      PYTHON_VER: 3.12
-      GOVER: "1.20"
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
       DAPR_CLI_REF: ${{ github.event.inputs.daprcli_commit }}
       DAPR_REF: ${{ github.event.inputs.daprdapr_commit }}
+      CHECKOUT_REPO: ${{ github.repository }}
+      CHECKOUT_REF: ${{ github.ref }}
+    outputs:
+      DAPR_INSTALL_URL: ${{ env.DAPR_INSTALL_URL }}
+      DAPR_CLI_VER: ${{ steps.outputs.outputs.DAPR_CLI_VER }}
+      DAPR_RUNTIME_VER: ${{ steps.outputs.outputs.DAPR_RUNTIME_VER }}
+      CHECKOUT_REPO: ${{ steps.outputs.outputs.CHECKOUT_REPO }}
+      CHECKOUT_REF: ${{ steps.outputs.outputs.CHECKOUT_REF }}
+      DAPR_REF: ${{ steps.outputs.outputs.DAPR_REF }}
     steps:
       - name: Parse repository_dispatch payload
         if: github.event_name == 'repository_dispatch'
@@ -50,33 +57,30 @@ jobs:
         with:
           repository: ${{ env.CHECKOUT_REPO }}
           ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Run go mod tidy check diff
+        run: make modtidy check-diff
+
       - name: Determine latest Dapr Runtime version
         run: |
           RUNTIME_VERSION=$(curl -s "https://api.github.com/repos/dapr/dapr/releases/latest" | grep '"tag_name"' | cut -d ':' -f2 | tr -d '",v')
           echo "DAPR_RUNTIME_VER=$RUNTIME_VERSION" >> $GITHUB_ENV
           echo "Found $RUNTIME_VERSION"
+
       - name: Determine latest Dapr Cli version
         run: |
           CLI_VERSION=$(curl -s "https://api.github.com/repos/dapr/cli/releases/latest" | grep '"tag_name"' | cut -d ':' -f2 | tr -d '",v')
           echo "DAPR_CLI_VER=$CLI_VERSION" >> $GITHUB_ENV
           echo "Found $CLI_VERSION"
-      - name: Set up Python ${{ env.PYTHON_VER }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VER }}
-      - name: Install Mechanical Markdown
-        run: |
-          python -m pip install --upgrade pip
-          pip install mechanical-markdown
-      - name: Run go mod tidy check diff
-        run: make modtidy check-diff
+
       - name: Set up Dapr CLI
         run: wget -q ${{ env.DAPR_INSTALL_URL }} -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
-      - name: Set up Go ${{ env.GOVER }}
-        if: env.DAPR_REF != '' || env.DAPR_CLI_REF != ''
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GOVER }}
+
       - name: Checkout Dapr CLI repo to override dapr command.
         uses: actions/checkout@v4
         if: env.DAPR_CLI_REF != ''
@@ -84,6 +88,7 @@ jobs:
           repository: dapr/cli
           ref: ${{ env.DAPR_CLI_REF }}
           path: cli
+
       - name: Checkout Dapr repo to override daprd.
         uses: actions/checkout@v4
         if: env.DAPR_REF != ''
@@ -91,38 +96,108 @@ jobs:
           repository: dapr/dapr
           ref: ${{ env.DAPR_REF }}
           path: dapr_runtime
-      - name: Build and override dapr cli with referenced commit.
+
+      - name: Build dapr cli with referenced commit.
         if: env.DAPR_CLI_REF != ''
         run: |
           cd cli
           make
-          sudo cp dist/linux_amd64/release/dapr /usr/local/bin/dapr
-          cd ..
-      - name: Initialize Dapr runtime ${{ env.DAPR_RUNTIME_VER }}
-        run: |
-          dapr uninstall --all
-          dapr init --runtime-version ${{ env.DAPR_RUNTIME_VER }}
-      - name: Build and override daprd with referenced commit.
+          mkdir -p $HOME/artifacts/$GITHUB_SHA/
+          sudo cp dist/linux_amd64/release/dapr $HOME/artifacts/$GITHUB_SHA/dapr
+
+      - name: Build daprd and placement with referenced commit.
         if: env.DAPR_REF != ''
         run: |
           cd dapr_runtime
           make
-          mkdir -p $HOME/.dapr/bin/
-          cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
-          cd ..
-      - name: Override placement service.
-        if: env.DAPR_REF != ''
+          mkdir -p $HOME/artifacts/$GITHUB_SHA/
+          cp dist/linux_amd64/release/daprd $HOME/artifacts/$GITHUB_SHA/daprd
+          cp dist/linux_amd64/release/placement $HOME/artifacts/$GITHUB_SHA/placement
+
+
+      - name: Upload dapr-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dapr-artifacts
+          path: $HOME/artifacts/$GITHUB_SHA/
+          if-no-files-found: warn
+          retention-days: 1
+          compression-level: 0
+
+      - name: Outputs
         run: |
-          docker stop dapr_placement
-          cd dapr_runtime
-          ./dist/linux_amd64/release/placement --healthz-port 9091 &
+          echo "DAPR_INSTALL_URL=$DAPR_INSTALL_URL"
+          echo "DAPR_CLI_VER=$DAPR_CLI_VER" >> "$GITHUB_OUTPUT"
+          echo "DAPR_RUNTIME_VER=$DAPR_RUNTIME_VER" >> "$GITHUB_OUTPUT"
+          echo "CHECKOUT_REPO=$CHECKOUT_REPO" >> "$GITHUB_OUTPUT"
+          echo "CHECKOUT_REF=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+          echo "DAPR_REF=$DAPR_REF" >> "$GITHUB_OUTPUT"
+
   validate-example:
-    needs: [ setup ]
+    needs: setup
     runs-on: ubuntu-latest
+    env:
+      PYTHON_VER: 3.12
+      GOOS: linux
+      GOARCH: amd64
+      GOPROXY: https://proxy.golang.org
+      DAPR_INSTALL_URL: ${{ needs.setup.outputs.DAPR_INSTALL_URL }}
+      DAPR_CLI_VER: ${{ needs.setup.outputs.DAPR_CLI_VER }}
+      DAPR_RUNTIME_VER: ${{ needs.setup.outputs.DAPR_RUNTIME_VER }}
+      DAPR_CLI_REF: ${{ github.event.inputs.daprcli_commit }}
+      DAPR_REF: ${{ github.event.inputs.daprdapr_commit }}
+
     strategy:
       matrix:
-        examples: [ "grpc-service", "configuration", "hello-world", "pubsub", "service", "actor" ]
+        examples: [ "actor", "configuation", "grpc-service", "hello-world", "pubsub", "service", "socket" ]
     steps:
+      - name: Make Artifacts destination folder
+        run: |
+          mkdir -p $HOME/artifacts/$GITHUB_SHA/
+
+      - name: Retrieve dapr-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dapr-artifacts
+          path: $HOME/artifacts/$GITHUB_SHA/
+
+      - name: Set up Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Set up Dapr CLI
+        run: wget -q ${{ env.DAPR_INSTALL_URL }} -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
+
+      - name: Override dapr cli with referenced commit.
+        if: env.DAPR_CLI_REF != ''
+        run: |
+          sudo cp $HOME/artifacts/$GITHUB_SHA/dapr /usr/local/bin/dapr
+
+      - name: Initialize Dapr runtime ${{ env.DAPR_RUNTIME_VER }}
+        run: |
+          dapr uninstall --all
+          dapr init --runtime-version ${{ env.DAPR_RUNTIME_VER }}
+
+      - name: Override daprd and placement service with referenced commit.
+        if: env.DAPR_REF != ''
+        run: |
+          mkdir -p $HOME/.dapr/bin/
+          cp $HOME/artifacts/$GITHUB_SHA/daprd $HOME/.dapr/bin/daprd
+          docker stop dapr_placement
+          $HOME/artifacts/$GITHUB_SHA/placement --healthz-port 9091 &
+
+      - name: Set up Python ${{ env.PYTHON_VER }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VER }}
+
+      - name: Install Mechanical Markdown
+        run: |
+          python -m pip install --upgrade pip
+          pip install mechanical-markdown
+
       - name: Check Example
         run: |
           cd examples

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -153,7 +153,7 @@ jobs:
 
     strategy:
       matrix:
-        examples: [ "actor", "configuation", "grpc-service", "hello-world", "pubsub", "service", "socket" ]
+        examples: [ "actor", "configuration", "grpc-service", "hello-world", "pubsub", "service", "socket" ]
     steps:
       - name: Check out code onto GOPATH
         uses: actions/checkout@v4

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -116,14 +116,14 @@ jobs:
           docker stop dapr_placement
           cd dapr_runtime
           ./dist/linux_amd64/release/placement --healthz-port 9091 &
-  validate-examples:
+  validate-example:
     needs: [ setup ]
     runs-on: ubuntu-latest
     strategy:
       matrix:
         examples: [ "grpc-service", "configuration", "hello-world", "pubsub", "service", "actor" ]
     steps:
-      - name: Check Examples
+      - name: Check Example
         run: |
           cd examples
           ./validate.sh ${{ matrix.examples }}

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -152,6 +152,7 @@ jobs:
       CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
 
     strategy:
+      fail-fast: false
       matrix:
         examples: [ "actor", "configuration", "grpc-service", "hello-world", "pubsub", "service", "socket" ]
     steps:

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -24,7 +24,7 @@ on:
     types: [ validate-examples ]
   merge_group:
 jobs:
-  validate:
+  setup:
     runs-on: ubuntu-latest
     env:
       PYTHON_VER: 3.12
@@ -116,12 +116,14 @@ jobs:
           docker stop dapr_placement
           cd dapr_runtime
           ./dist/linux_amd64/release/placement --healthz-port 9091 &
+  validate-examples:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        examples: [ "grpc-service", "configuration", "hello-world", "pubsub", "service", "actor" ]
+    steps:
       - name: Check Examples
         run: |
           cd examples
-          ./validate.sh grpc-service
-          ./validate.sh configuration
-          ./validate.sh hello-world
-          ./validate.sh pubsub
-          ./validate.sh service
-          ./validate.sh actor
+          ./validate.sh ${{ matrix.examples }}

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -9,20 +9,47 @@ on:
   pull_request:
     branches:
       - main
+      - release-*
+  workflow_dispatch:
+    inputs:
+      daprdapr_commit:
+        description: 'Dapr/Dapr commit to build custom daprd from'
+        required: false
+        default: ''
+      daprcli_commit:
+        description: 'Dapr/CLI commit to build custom dapr CLI from'
+        required: false
+        default: ''
+  repository_dispatch:
+    types: [ validate-examples ]
+  merge_group:
 jobs:
   validate:
     runs-on: ubuntu-latest
     env:
-      PYTHON_VER: 3.7
+      PYTHON_VER: 3.12
       GOVER: "1.20"
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_CLI_REF: ""
-      DAPR_REF: ""
+      DAPR_CLI_REF: ${{ github.event.inputs.daprcli_commit }}
+      DAPR_REF: ${{ github.event.inputs.daprdapr_commit }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Parse repository_dispatch payload
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          if [ ${{ github.event.client_payload.command }} = "ok-to-test" ]; then
+            echo "CHECKOUT_REPO=${{ github.event.client_payload.pull_head_repo }}" >> $GITHUB_ENV
+            echo "CHECKOUT_REF=${{ github.event.client_payload.pull_head_ref }}" >> $GITHUB_ENV
+            echo "DAPR_REF=master" >> $GITHUB_ENV
+          fi
+
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CHECKOUT_REPO }}
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Determine latest Dapr Runtime version
         run: |
           RUNTIME_VERSION=$(curl -s "https://api.github.com/repos/dapr/dapr/releases/latest" | grep '"tag_name"' | cut -d ':' -f2 | tr -d '",v')
@@ -34,7 +61,7 @@ jobs:
           echo "DAPR_CLI_VER=$CLI_VERSION" >> $GITHUB_ENV
           echo "Found $CLI_VERSION"
       - name: Set up Python ${{ env.PYTHON_VER }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VER }}
       - name: Install Mechanical Markdown
@@ -47,18 +74,18 @@ jobs:
         run: wget -q ${{ env.DAPR_INSTALL_URL }} -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
       - name: Set up Go ${{ env.GOVER }}
         if: env.DAPR_REF != '' || env.DAPR_CLI_REF != ''
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOVER }}
       - name: Checkout Dapr CLI repo to override dapr command.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: env.DAPR_CLI_REF != ''
         with:
           repository: dapr/cli
           ref: ${{ env.DAPR_CLI_REF }}
           path: cli
       - name: Checkout Dapr repo to override daprd.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: env.DAPR_REF != ''
         with:
           repository: dapr/dapr

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -125,6 +125,7 @@ jobs:
           compression-level: 0
 
       - name: Outputs
+        id: outputs
         run: |
           echo "DAPR_INSTALL_URL=$DAPR_INSTALL_URL"
           echo "DAPR_CLI_VER=$DAPR_CLI_VER" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     tags:
       - v*
   pull_request:
@@ -114,13 +115,13 @@ jobs:
           cp dist/linux_amd64/release/daprd $HOME/artifacts/$GITHUB_SHA/daprd
           cp dist/linux_amd64/release/placement $HOME/artifacts/$GITHUB_SHA/placement
 
-
       - name: Upload dapr-artifacts
         uses: actions/upload-artifact@v4
+        if: env.DAPR_REF != '' || env.DAPR_CLI_REF != ''
         with:
           name: dapr-artifacts
           path: $HOME/artifacts/$GITHUB_SHA/
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 1
           compression-level: 0
 
@@ -149,7 +150,6 @@ jobs:
       DAPR_REF: ${{ github.event.inputs.daprdapr_commit }}
       CHECKOUT_REPO: ${{ needs.setup.outputs.CHECKOUT_REPO }}
       CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
-
 
     strategy:
       matrix:

--- a/examples/grpc-service/README.md
+++ b/examples/grpc-service/README.md
@@ -17,7 +17,7 @@ output_match_mode: substring
 expected_stdout_lines:
   - 'Received: Dapr'
 background: true
-sleep: 15
+sleep: 30
 -->
 
 ```bash


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
This PR introduces an improved github action workflow for validating the examples.

Changes:

- Removes the hard-coded commit reference for the runtime.
- Implement events triggering a test with a custom ref for runtime/cli
- Split examples into singular jobs
  -  Allows testing all examples even with individual failures
  -  The log outputs are now split by example
- Bumps all actions to the latest versions.
- Use the repo `go.mod` as a source for the go version.
- Adds the socket example to the validation list


The validation run time has been decreased from 4 minutes to 2 minutes when using the latest release of the cli and daprd. This should remain fairly consistent with subsequent examples running in parallel with each other.

Old run: https://github.com/dapr/go-sdk/actions/runs/7495289203/job/20405047466
New run: https://github.com/dapr/go-sdk/actions/runs/7584941308

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->
Unreferenced

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [x] ~~Created~~/updated tests
* [ ] Extended the documentation
