### PR TITLE
Dependabot added in workflow.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/.github/workflows/dapr-bot"
+    schedule:
+      interval: "daily"
+      


### PR DESCRIPTION
* Made a change in the manifest file, to run dependency checks daily for dapr-bot.

Issue: https://github.com/dapr/go-sdk/issues/523
