### PR TITLE
Update holopin.yml to award SDK badge to contributors 

### DIFF
--- a/.github/holopin.yml
+++ b/.github/holopin.yml
@@ -1,6 +1,6 @@
 organization: dapr
-defaultSticker: clmjkxscc122740fl0mkmb7egi
+defaultSticker: clrqfdv4x24910fl5n4iwu5oa
 stickers:
   -
-    id: clmjkxscc122740fl0mkmb7egi
-    alias: ghc2023
+    id: clrqfdv4x24910fl5n4iwu5oa
+    alias: sdk-badge


### PR DESCRIPTION
# Description

The `yaml` file to award contribution badges has been updated such that each contributor can be awarded an SDK badge for their contribution to this repo.

## Issue reference

This PR fixes #546 

### Please reference the issue this PR will close: #546 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly.
* [x] Correct and accurate change has been done as per the issue suggestion.
* [x] YAML doesn't throw any error.