### PR TITLE
fix: stop schedule field from always being initialised

### DIFF
--- a/client/scheduling.go
+++ b/client/scheduling.go
@@ -24,7 +24,7 @@ import (
 
 type Job struct {
 	Name     string
-	Schedule string
+	Schedule string // Optional
 	Repeats  uint32 // Optional
 	DueTime  string // Optional
 	TTL      string // Optional
@@ -33,11 +33,10 @@ type Job struct {
 
 // ScheduleJobAlpha1 raises and schedules a job.
 func (c *GRPCClient) ScheduleJobAlpha1(ctx context.Context, job *Job) error {
-	// TODO: Assert job fields are defined: Name, Schedule, Data
+	// TODO: Assert job fields are defined: Name, Data
 	jobRequest := &pb.Job{
-		Name:     job.Name,
-		Schedule: &job.Schedule,
-		Data:     job.Data,
+		Name: job.Name,
+		Data: job.Data,
 	}
 
 	if job.Schedule != "" {


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
This fix stops the schedule field from being initialised unless otherwise explicitly with a value.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_N/A_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
