### PR TITLE
[Actors API] update err desc to be more explicit

### DIFF
--- a/actor/manager/manager.go
+++ b/actor/manager/manager.go
@@ -298,7 +298,7 @@ func suiteMethod(method reflect.Method) (*MethodType, error) {
 	)
 
 	if outNum > 2 || outNum == 0 {
-		return nil, errors.New("num out invalid")
+		return nil, errors.New("num out invalid, add a return value to the function")
 	}
 
 	// The latest return type of the method must be error.


### PR DESCRIPTION
Ran into some errors with using the Actors API & reminders. This PR is a nice to have making it explicit to newbie actor users what the error means.

[This PR](https://github.com/dapr/go-sdk/pull/619#pullrequestreview-2388993301) fixes one of the issues, which I also had locally and confirm resolves the err: 
```
== APP == 2024/10/22 13:54:53 http: superfluous response.WriteHeader call from [github.com/dapr/go-sdk/service/http.(*Server).registerBaseHandler.func6](http://github.com/dapr/go-sdk/service/http.(*Server).registerBaseHandler.func6) (topic.go:214)
```
