### PR TITLE
Introduce interface for topic event subscriber

### DIFF
--- a/daprdocs/content/en/go-sdk-docs/go-service/grpc-service.md
+++ b/daprdocs/content/en/go-sdk-docs/go-service/grpc-service.md
@@ -83,6 +83,35 @@ if err != nil {
 }
 ```
 
+You can also create a custom type that implements the `TopicEventSubscriber` interface to handle your events:
+
+```go
+type EventHandler struct {
+	// any data or references that your event handler needs.
+}
+
+func (h *EventHandler) Handle(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
+    log.Printf("event - PubsubName:%s, Topic:%s, ID:%s, Data: %v", e.PubsubName, e.Topic, e.ID, e.Data)
+    // do something with the event
+    return true, nil
+}
+```
+
+The `EventHandler` can then be added using the `AddTopicEventSubscriber` method:
+
+```go
+sub := &common.Subscription{
+    PubsubName: "messages",
+    Topic:      "topic1",
+}
+eventHandler := &EventHandler{
+// initialize any fields
+}
+if err := s.AddTopicEventSubscriber(sub, eventHandler); err != nil {
+    log.Fatalf("error adding topic subscription: %v", err)
+}
+```
+
 ### Service Invocation Handler
 To handle service invocations you will need to add at least one service invocation handler before starting the service:
 

--- a/daprdocs/content/en/go-sdk-docs/go-service/http-service.md
+++ b/daprdocs/content/en/go-sdk-docs/go-service/http-service.md
@@ -78,6 +78,35 @@ if err != nil {
 }
 ```
 
+You can also create a custom type that implements the `TopicEventSubscriber` interface to handle your events:
+
+```go
+type EventHandler struct {
+	// any data or references that your event handler needs.
+}
+
+func (h *EventHandler) Handle(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
+    log.Printf("event - PubsubName:%s, Topic:%s, ID:%s, Data: %v", e.PubsubName, e.Topic, e.ID, e.Data)
+    // do something with the event
+    return true, nil
+}
+```
+
+The `EventHandler` can then be added using the `AddTopicEventSubscriber` method:
+
+```go
+sub := &common.Subscription{
+    PubsubName: "messages",
+    Topic:      "topic1",
+}
+eventHandler := &EventHandler{
+// initialize any fields
+}
+if err := s.AddTopicEventSubscriber(sub, eventHandler); err != nil {
+    log.Fatalf("error adding topic subscription: %v", err)
+}
+```
+
 ### Service Invocation Handler
 To handle service invocations you will need to add at least one service invocation handler before starting the service:
 

--- a/service/common/service.go
+++ b/service/common/service.go
@@ -27,18 +27,23 @@ const (
 )
 
 // Service represents Dapr callback service.
+//
+//nolint:interfacebloat
 type Service interface {
 	// AddHealthCheckHandler sets a health check handler, name: http (router) and grpc (invalid).
 	AddHealthCheckHandler(name string, fn HealthCheckHandler) error
 	// AddServiceInvocationHandler appends provided service invocation handler with its name to the service.
 	AddServiceInvocationHandler(name string, fn ServiceInvocationHandler) error
 	// AddTopicEventHandler appends provided event handler with its topic and optional metadata to the service.
-	// Note, retries are only considered when there is an error. Lack of error is considered as a success
+	// Note, retries are only considered when there is an error. Lack of error is considered as a success.
 	AddTopicEventHandler(sub *Subscription, fn TopicEventHandler) error
+	// AddTopicEventSubscriber appends the provided subscriber with its topic and optional metadata to the service.
+	// Note, retries are only considered when there is an error. Lack of error is considered as a success.
+	AddTopicEventSubscriber(sub *Subscription, subscriber TopicEventSubscriber) error
 	// AddBindingInvocationHandler appends provided binding invocation handler with its name to the service.
 	AddBindingInvocationHandler(name string, fn BindingInvocationHandler) error
 	// RegisterActorImplFactory Register a new actor to actor runtime of go sdk
-	// Deprecated: use RegisterActorImplFactoryContext instead
+	// Deprecated: use RegisterActorImplFactoryContext instead.
 	RegisterActorImplFactory(f actor.Factory, opts ...config.Option)
 	// RegisterActorImplFactoryContext Register a new actor to actor runtime of go sdk
 	RegisterActorImplFactoryContext(f actor.FactoryContext, opts ...config.Option)
@@ -49,7 +54,7 @@ type Service interface {
 	Start() error
 	// Stop stops the previously started service.
 	Stop() error
-	// Gracefully stops the previous started service
+	// Gracefully stops the previous started service.
 	GracefulStop() error
 }
 
@@ -60,3 +65,13 @@ type (
 	JobEventHandler          func(ctx context.Context, in *JobEvent) error
 	HealthCheckHandler       func(context.Context) error
 )
+
+type TopicEventSubscriber interface {
+	Handle(ctx context.Context, e *TopicEvent) (retry bool, err error)
+}
+
+// Handle converts TopicEventHandler into an adapter that implements
+// TopicEventSubscriber.
+func (h TopicEventHandler) Handle(ctx context.Context, e *TopicEvent) (retry bool, err error) {
+	return h(ctx, e)
+}

--- a/service/internal/topicregistrar.go
+++ b/service/internal/topicregistrar.go
@@ -14,11 +14,11 @@ type TopicRegistrar map[string]*TopicRegistration
 // TopicRegistration encapsulates the subscription and handlers.
 type TopicRegistration struct {
 	Subscription   *TopicSubscription
-	DefaultHandler common.TopicEventHandler
-	RouteHandlers  map[string]common.TopicEventHandler
+	DefaultHandler common.TopicEventSubscriber
+	RouteHandlers  map[string]common.TopicEventSubscriber
 }
 
-func (m TopicRegistrar) AddSubscription(sub *common.Subscription, fn common.TopicEventHandler) error {
+func (m TopicRegistrar) AddSubscription(sub *common.Subscription, fn common.TopicEventSubscriber) error {
 	if sub.Topic == "" {
 		return errors.New("topic name required")
 	}
@@ -40,7 +40,7 @@ func (m TopicRegistrar) AddSubscription(sub *common.Subscription, fn common.Topi
 	if !ok {
 		ts = &TopicRegistration{
 			Subscription:   NewTopicSubscription(sub.PubsubName, sub.Topic),
-			RouteHandlers:  make(map[string]common.TopicEventHandler),
+			RouteHandlers:  make(map[string]common.TopicEventSubscriber),
 			DefaultHandler: nil,
 		}
 		ts.Subscription.SetMetadata(sub.Metadata)

--- a/service/internal/topicregistrar_test.go
+++ b/service/internal/topicregistrar_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestTopicRegistrarValidation(t *testing.T) {
-	fn := func(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
+	fn := common.TopicEventHandler(func(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
 		return false, nil
-	}
+	})
 	tests := map[string]struct {
 		sub common.Subscription
-		fn  common.TopicEventHandler
+		fn  common.TopicEventSubscriber
 		err string
 	}{
 		"pubsub required": {
@@ -75,9 +75,9 @@ func TestTopicRegistrarValidation(t *testing.T) {
 }
 
 func TestTopicAddSubscriptionMetadata(t *testing.T) {
-	handler := func(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
+	handler := common.TopicEventHandler(func(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
 		return false, nil
-	}
+	})
 	topicRegistrar := internal.TopicRegistrar{}
 	sub := &common.Subscription{
 		PubsubName: "pubsubname",


### PR DESCRIPTION
# Description

I introduced the `TopicEventSubscriber` interface and added an `AddTopicEventSubscriber` method to the `Server` interface. `TopicEventSubscriber` will allow more complex subscribers to be registered that are using structs so that dependencies like `sql.DB` objects or other parameters can be provided to subscribers and used to process incoming events.

I modified `TopicRegistrar` to register and store `TopicEventSubscriber` instead of `TopicEventHandler` in the `TopicRegistration struct. I created an adapter for `TopicEventHandler` so that it implements the new `TopicEventSubscriber` interface and can continue to be used without modification.

* I introduced the `TopicEventSubscriber` type instead of rewriting the `TopicEventHandler` type to not break existing code. I used the pattern that `net/http` uses for `Handler` and `HandlerFunc`.
* I did not define any new tests, but I modified the existing tests to work. Given the way that I changed `TopicRegistration` and making `TopicEventHandler` implement `TopicEventSubscriber`, I didn't think that any additional tests were necessary.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #660

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
