### PR TITLE
chore: bump validation dapr runtime to 1.15.0-rc.2

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -32,15 +32,15 @@ jobs:
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_CLI_REF: 8bf3a1605f7b2ecfa7d4633ce4c5de13cdb65c5e
-      DAPR_REF: c86a77f6db5fb9f294f39d096ff0d9a053e55982
+      DAPR_CLI_REF: ${{ github.event.inputs.daprcli_commit }}
+      DAPR_REF: ${{ github.event.inputs.daprdapr_commit }}
       CHECKOUT_REPO: ${{ github.repository }}
       CHECKOUT_REF: ${{ github.ref }}
     outputs:
       DAPR_INSTALL_URL: ${{ env.DAPR_INSTALL_URL }}
       DAPR_CLI_VER: ${{ steps.outputs.outputs.DAPR_CLI_VER }}
       DAPR_CLI_REF: ${{ steps.outputs.outputs.DAPR_CLI_REF }}
-      DAPR_RUNTIME_VER: ${{ steps.outputs.outputs.DAPR_RUNTIME_VER }}
+      DAPR_RUNTIME_VER: 1.15.0-rc.2
       CHECKOUT_REPO: ${{ steps.outputs.outputs.CHECKOUT_REPO }}
       CHECKOUT_REF: ${{ steps.outputs.outputs.CHECKOUT_REF }}
       DAPR_REF: ${{ steps.outputs.outputs.DAPR_REF }}

--- a/examples/actor/README.md
+++ b/examples/actor/README.md
@@ -17,8 +17,8 @@ expected_stdout_lines:
   - '== APP == get post request =  laurence'
   - '== APP == get req =  hello'
   - '== APP == get req =  hello'
-  - '== APP == receive reminder =  testReminderName  state =  "hello" duetime =  5s period =  5s'
-  - '== APP == receive reminder =  testReminderName  state =  "hello" duetime =  5s period =  5s'
+  - '== APP == receive reminder =  testReminderName  state =  "hello"'
+  - '== APP == receive reminder =  testReminderName  state =  "hello"'
 background: true
 sleep: 30
 timeout_seconds: 60
@@ -99,6 +99,6 @@ dapr stop --app-id  actor-serving
 == APP == get post request =  laurence
 == APP == get req =  hello
 == APP == get req =  hello
-== APP == receive reminder =  testReminderName  state =  "hello" duetime =  5s period =  5s
-== APP == receive reminder =  testReminderName  state =  "hello" duetime =  5s period =  5s
+== APP == receive reminder =  testReminderName  state =  "hello"
+== APP == receive reminder =  testReminderName  state =  "hello"
 ```

--- a/examples/actor/serving/main.go
+++ b/examples/actor/serving/main.go
@@ -124,7 +124,7 @@ func (t *TestActor) IncrementAndGet(ctx context.Context, stateKey string) (*api.
 }
 
 func (t *TestActor) ReminderCall(reminderName string, state []byte, dueTime string, period string) {
-	fmt.Println("receive reminder = ", reminderName, " state = ", string(state), "duetime = ", dueTime, "period = ", period)
+	fmt.Println("receive reminder = ", reminderName, " state = ", string(state))
 }
 
 func main() {

--- a/examples/service/client/main.go
+++ b/examples/service/client/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	in := &dapr.InvokeBindingRequest{
 		Name:      "example-http-binding",
-		Operation: "create",
+		Operation: "get",
 	}
 	if err := client.InvokeOutputBinding(ctx, in); err != nil {
 		panic(err)

--- a/examples/service/config/binding.yaml
+++ b/examples/service/config/binding.yaml
@@ -7,6 +7,6 @@ spec:
   version: v1
   metadata:
   - name: url
-    value: https://http2.pro/api/v1
+    value: https://sandbox.api.service.nhs.uk/hello-world/hello/world
   - name: method
     value: GET


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
* Bumps the runtime version used in the example validation to 1.15.0-rc.2
* Fixes the service invocation (and bindings) example which used a deprecated endpoint to test a binding invocation.
* Fixes the actor example

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
