### PR TITLE
Add trace headers to http subscriptions

### DIFF
--- a/service/common/type.go
+++ b/service/common/type.go
@@ -47,6 +47,10 @@ type TopicEvent struct {
 	PubsubName string `json:"pubsubname"`
 	// Metadata is the custom metadata attached to the event.
 	Metadata map[string]string `json:"metadata,omitempty"`
+	// TraceID is the tracing header identifier for the incoming event
+	TraceID string `json:"traceid"`
+	// TraceParent is name of the parent trace identifier for the incoming event
+	TraceParent string `json:"traceparent"`
 }
 
 func (e *TopicEvent) Struct(target interface{}) error {

--- a/service/http/topic.go
+++ b/service/http/topic.go
@@ -69,6 +69,10 @@ type topicEventJSON struct {
 	Topic string `json:"topic"`
 	// PubsubName is name of the pub/sub this message came from
 	PubsubName string `json:"pubsubname"`
+	// TraceID is the tracing header identifier for the incoming event
+	TraceID string `json:"traceid"`
+	// TraceParent is name of the parent trace identifier for the incoming event
+	TraceParent string `json:"traceparent"`
 }
 
 func (in topicEventJSON) getData() (data any, rawData []byte) {
@@ -309,6 +313,8 @@ func (s *Server) AddTopicEventSubscriber(sub *common.Subscription, subscriber co
 				PubsubName:      in.PubsubName,
 				Topic:           in.Topic,
 				Metadata:        getCustomMetdataFromHeaders(r),
+				TraceID:         in.TraceID,
+				TraceParent:     in.TraceParent,
 			}
 
 			w.Header().Add("Content-Type", "application/json")

--- a/service/http/topic_test.go
+++ b/service/http/topic_test.go
@@ -71,7 +71,9 @@ func TestEventHandler(t *testing.T) {
 		"comexampleextension1" : "value",
 		"comexampleothervalue" : 5,
 		"datacontenttype" : "application/json",
-		"data" : "eyJtZXNzYWdlIjoiaGVsbG8ifQ=="
+		"data" : "eyJtZXNzYWdlIjoiaGVsbG8ifQ==",
+		"traceid": "aaa",
+		"traceparent": "bbb",
 	}`
 
 	s := newServer("", nil)


### PR DESCRIPTION
Related to https://github.com/dapr/go-sdk/issues/355, this PR adds trace headers when present on HTTP requests coming from Dapr. This ask has been a recurring theme among Dapr users.
