### PR TITLE
Fix-docs-card-rendering

### DIFF
--- a/daprdocs/content/en/go-sdk-docs/_index.md
+++ b/daprdocs/content/en/go-sdk-docs/_index.md
@@ -15,14 +15,14 @@ cascade:
 A client library to help build Dapr applications in Go. This client supports all public Dapr APIs while focusing on idiomatic Go experiences and developer productivity.
 
 {{< cardpane >}}
-{{< card title="**Client**">}}
+{{% card title="**Client**"%}}
   Use the Go Client SDK for invoking public Dapr APIs
 
   [**Learn more about the Go Client SDK**]({{% ref go-client %}})
-{{< /card >}}
-{{< card title="**Service**">}}
+{{% /card %}}
+{{% card title="**Service**"%}}
   Use the Dapr Service (Callback) SDK for Go to create services that will be invoked by Dapr.
 
   [**Learn more about the Go Service (Callback) SDK**]({{% ref go-service %}})
-{{< /card >}}
+{{% /card %}}
 {{< /cardpane >}}


### PR DESCRIPTION
# Description

This change fixes the rendering in the 1.16 docs. The inner `card` element contains Markdown formatting and should therefore use the `%`. The card is then rendered as HTML so the outer `cardpanel` should remain using `<>`.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
