### PR TITLE
Implement GRPC Actors

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -164,6 +164,7 @@ jobs:
         examples:
           [
             "actor",
+            "actor-grpc",
             "configuration",
             "conversation-alpha1",
             "conversation-alpha2",

--- a/actor/runtime/actor_runtime.go
+++ b/actor/runtime/actor_runtime.go
@@ -93,6 +93,14 @@ func (r *ActorRunTimeContext) GetJSONSerializedConfig() ([]byte, error) {
 	return data, err
 }
 
+// RegisteredActorTypes returns the names of the actor types registered on
+// this runtime through RegisterActorFactory.
+func (r *ActorRunTimeContext) RegisteredActorTypes() []string {
+	types := make([]string, len(r.config.RegisteredActorTypes))
+	copy(types, r.config.RegisteredActorTypes)
+	return types
+}
+
 func (r *ActorRunTimeContext) InvokeActorMethod(ctx context.Context, actorTypeName, actorID, actorMethod string, payload []byte) ([]byte, actorErr.ActorErr) {
 	mng, ok := r.actorManagers.Load(actorTypeName)
 	if !ok {

--- a/actor/runtime/actor_runtime_test.go
+++ b/actor/runtime/actor_runtime_test.go
@@ -34,6 +34,27 @@ func TestGetActorRuntime(t *testing.T) {
 	assert.NotNil(t, rt)
 }
 
+func TestRegisteredActorTypes(t *testing.T) {
+	rt := NewActorRuntimeContext()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	assert.Empty(t, rt.RegisteredActorTypes())
+
+	mockServer := actorMock.NewMockActorManagerContext(ctrl)
+	rt.actorManagers.Store("testActorType", mockServer)
+
+	mockServer.EXPECT().RegisterActorImplFactory(gomock.Any())
+	rt.RegisterActorFactory(actorMock.ActorImplFactoryCtx)
+
+	types := rt.RegisteredActorTypes()
+	assert.Equal(t, []string{"testActorType"}, types)
+
+	// Mutating the returned slice must not affect the runtime config.
+	types[0] = "mutated"
+	assert.Equal(t, []string{"testActorType"}, rt.RegisteredActorTypes())
+}
+
 func TestRegisterActorFactoryAndInvokeMethod(t *testing.T) {
 	rt := NewActorRuntime()
 	ctrl := gomock.NewController(t)

--- a/client/actor.go
+++ b/client/actor.go
@@ -66,6 +66,13 @@ func (c *GRPCClient) InvokeActor(ctx context.Context, in *InvokeActorRequest) (o
 		Data:      in.Data,
 	}
 
+	// Propagate the reentrancy id when invoking from within an actor callback
+	// received over the actor event stream, so reentrant calls share the
+	// caller's reentrancy stack.
+	if id, ok := reentrancyIDFromContext(ctx); ok {
+		req.Metadata = map[string]string{reentrancyIDMetadataKey: id}
+	}
+
 	resp, err := c.protoClient.InvokeActor(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("error invoking binding %s/%s: %w", in.ActorType, in.ActorID, err)

--- a/client/actor.go
+++ b/client/actor.go
@@ -68,9 +68,13 @@ func (c *GRPCClient) InvokeActor(ctx context.Context, in *InvokeActorRequest) (o
 
 	// Propagate the reentrancy id when invoking from within an actor callback
 	// received over the actor event stream, so reentrant calls share the
-	// caller's reentrancy stack.
+	// caller's reentrancy stack. Only the reentrancy key is set, preserving any
+	// other metadata already on the request.
 	if id, ok := reentrancyIDFromContext(ctx); ok {
-		req.Metadata = map[string]string{reentrancyIDMetadataKey: id}
+		if req.Metadata == nil {
+			req.Metadata = make(map[string]string)
+		}
+		req.Metadata[reentrancyIDMetadataKey] = id
 	}
 
 	resp, err := c.protoClient.InvokeActor(ctx, req)

--- a/client/actor_subscribe.go
+++ b/client/actor_subscribe.go
@@ -539,9 +539,20 @@ func actorErrMessage(aerr actorErr.ActorErr) string {
 }
 
 // anyToRawData unwraps the reminder/timer payload the sidecar sends as a
-// google.protobuf.Any. Payloads registered as raw bytes (the common case)
-// arrive as a wrapped BytesValue; typed payloads are rendered as JSON. This
-// mirrors how the sidecar serializes reminder data for the HTTP callbacks.
+// google.protobuf.Any into the JSON value to embed under the params "data"
+// field. The returned bytes are a JSON value, NOT raw bytes, so the caller
+// must embed them as json.RawMessage; marshalling them as []byte would
+// base64-encode them a second time and the actor runtime would decode the
+// wrong bytes.
+//
+// Payloads registered via the actor reminder/timer APIs arrive as a
+// BytesValue whose contents are already json.Marshal(registered) — i.e. a
+// base64-encoded JSON string — because the sidecar marshals the bytes before
+// wrapping them (see RegisterActorReminder/RegisterActorTimer in daprd's
+// pkg/api/universal/actors.go). api.ActorReminderParams.Data ([]byte) then
+// base64-decodes that string back to the registered bytes. Typed payloads are
+// rendered as JSON via protojson. This mirrors how the sidecar serializes
+// reminder/timer data for the HTTP callbacks.
 func anyToRawData(data *anypb.Any) []byte {
 	if data == nil {
 		return nil

--- a/client/actor_subscribe.go
+++ b/client/actor_subscribe.go
@@ -580,7 +580,13 @@ func withActorCallbackMetadata(ctx context.Context, md map[string]string) contex
 	if len(md) == 0 {
 		return ctx
 	}
-	return context.WithValue(ctx, actorCallbackMetadataCtxKey{}, md)
+	// Copy so the value carried on the context is independent of the protobuf
+	// request's map and cannot be mutated through it.
+	cp := make(map[string]string, len(md))
+	for k, v := range md {
+		cp[k] = v
+	}
+	return context.WithValue(ctx, actorCallbackMetadataCtxKey{}, cp)
 }
 
 // reentrancyIDFromContext returns the reentrancy id of the actor callback in

--- a/client/actor_subscribe.go
+++ b/client/actor_subscribe.go
@@ -108,7 +108,11 @@ type ActorEventSubscriptionOptions struct {
 // SubscribeActorEventsAlpha1 stream, dispatching callbacks pushed by the
 // sidecar to the ActorEventHandler and sending the correlated responses back.
 type actorEventSubscription struct {
-	ctx     context.Context
+	// ctx is an internal context derived from the caller's; cancel tears it
+	// down so a Recv blocked in run() unblocks promptly on Close.
+	ctx    context.Context
+	cancel context.CancelFunc
+
 	handler ActorEventHandler
 
 	// lock locks concurrent writes to the subscription stream.
@@ -145,13 +149,19 @@ func (c *GRPCClient) SubscribeActorEvents(ctx context.Context, handler ActorEven
 		return c.subscribeActorEventsInitialRequest(ctx, handler.RegisteredActorTypes(), opts)
 	}
 
-	stream, err := createStream(ctx)
+	// Derive an internal context so Close can cancel the stream (and any
+	// in-flight Recv) without depending on the caller cancelling ctx.
+	streamCtx, cancel := context.WithCancel(ctx)
+
+	stream, err := createStream(streamCtx)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
 	s := &actorEventSubscription{
-		ctx:          ctx,
+		ctx:          streamCtx,
+		cancel:       cancel,
 		handler:      handler,
 		stream:       stream,
 		createStream: createStream,
@@ -240,13 +250,18 @@ func (s *actorEventSubscription) Close() error {
 		return errors.New("actor event subscription already closed")
 	}
 
+	// Half-close the send side first, then cancel the stream context so a Recv
+	// blocked in run() unblocks promptly instead of waiting for the server to
+	// react to the half-close.
 	s.lock.Lock()
-	defer s.lock.Unlock()
-
+	var err error
 	if s.stream != nil {
-		return s.stream.CloseSend()
+		err = s.stream.CloseSend()
 	}
-	return nil
+	s.lock.Unlock()
+
+	s.cancel()
+	return err
 }
 
 // run reads callbacks from the stream and dispatches each on its own
@@ -559,17 +574,26 @@ func anyToRawData(data *anypb.Any) []byte {
 	}
 	msg, err := data.UnmarshalNew()
 	if err != nil {
-		// Unknown or unregistered payload type: fall back to the raw value.
-		return data.GetValue()
+		// Unknown or unregistered payload type: encode the raw bytes as a JSON
+		// string so the value stays valid JSON when embedded under params
+		// "data". The actor runtime base64-decodes it back to these bytes.
+		return rawBytesToJSON(data.GetValue())
 	}
 	if b, ok := msg.(*wrapperspb.BytesValue); ok {
 		return b.GetValue()
 	}
 	d, err := protojson.Marshal(msg)
 	if err != nil {
-		return data.GetValue()
+		return rawBytesToJSON(data.GetValue())
 	}
 	return d
+}
+
+// rawBytesToJSON encodes opaque bytes as a JSON string (base64) so they can be
+// embedded as a valid JSON value. json.Marshal of a []byte never errors.
+func rawBytesToJSON(b []byte) []byte {
+	out, _ := json.Marshal(b)
+	return out
 }
 
 // actorCallbackMetadataCtxKey carries the metadata of the actor callback

--- a/client/actor_subscribe.go
+++ b/client/actor_subscribe.go
@@ -185,7 +185,10 @@ func (c *GRPCClient) subscribeActorEventsInitialRequest(ctx context.Context, ent
 	}
 
 	if resp.GetInitialResponse() == nil {
-		return nil, fmt.Errorf("unexpected initial response from server: %v", resp)
+		return nil, errors.Join(
+			fmt.Errorf("unexpected initial response from server: %v", resp),
+			stream.CloseSend(),
+		)
 	}
 
 	return stream, nil
@@ -251,7 +254,13 @@ func (s *actorEventSubscription) Close() error {
 // reconnects with a backoff, re-sending the initial registration.
 func (s *actorEventSubscription) run() {
 	for {
-		msg, err := s.stream.Recv()
+		// Snapshot the current stream under the lock; reconnect may replace it
+		// concurrently with the send goroutines below.
+		s.lock.Lock()
+		stream := s.stream
+		s.lock.Unlock()
+
+		msg, err := stream.Recv()
 		if err != nil {
 			if s.closed.Load() || s.ctx.Err() != nil {
 				return
@@ -268,7 +277,10 @@ func (s *actorEventSubscription) run() {
 			continue
 		}
 
-		go s.dispatch(msg)
+		// Dispatch on the stream that delivered the message so the response is
+		// sent back on the same stream, keeping request ids correlated even if
+		// a reconnect swaps the stream while the handler runs.
+		go s.dispatch(stream, msg)
 	}
 }
 
@@ -303,23 +315,23 @@ func (s *actorEventSubscription) reconnect() bool {
 }
 
 // dispatch routes a single callback pushed by the sidecar to the handler and
-// sends the correlated response, echoing the request id.
-func (s *actorEventSubscription) dispatch(msg *pb.SubscribeActorEventsResponseAlpha1) {
+// sends the correlated response on stream, echoing the request id.
+func (s *actorEventSubscription) dispatch(stream pb.Dapr_SubscribeActorEventsAlpha1Client, msg *pb.SubscribeActorEventsResponseAlpha1) {
 	switch t := msg.GetResponseType().(type) {
 	case *pb.SubscribeActorEventsResponseAlpha1_InvokeRequest:
-		s.handleInvoke(t.InvokeRequest)
+		s.handleInvoke(stream, t.InvokeRequest)
 	case *pb.SubscribeActorEventsResponseAlpha1_ReminderRequest:
-		s.handleReminder(t.ReminderRequest)
+		s.handleReminder(stream, t.ReminderRequest)
 	case *pb.SubscribeActorEventsResponseAlpha1_TimerRequest:
-		s.handleTimer(t.TimerRequest)
+		s.handleTimer(stream, t.TimerRequest)
 	case *pb.SubscribeActorEventsResponseAlpha1_DeactivateRequest:
-		s.handleDeactivate(t.DeactivateRequest)
+		s.handleDeactivate(stream, t.DeactivateRequest)
 	default:
 		logger.Printf("Unexpected actor event message type: %T", t)
 	}
 }
 
-func (s *actorEventSubscription) handleInvoke(req *pb.SubscribeActorEventsResponseInvokeRequestAlpha1) {
+func (s *actorEventSubscription) handleInvoke(stream pb.Dapr_SubscribeActorEventsAlpha1Client, req *pb.SubscribeActorEventsResponseInvokeRequestAlpha1) {
 	// Make the callback metadata (content-type, Dapr-Reentrancy-Id, ...)
 	// available to the actor code: InvokeActor propagates the reentrancy id
 	// from this context on outbound actor invocations.
@@ -327,7 +339,7 @@ func (s *actorEventSubscription) handleInvoke(req *pb.SubscribeActorEventsRespon
 
 	data, aerr := s.handler.InvokeActorMethod(ctx, req.GetActorType(), req.GetActorId(), req.GetMethod(), req.GetData())
 	if aerr != actorErr.Success {
-		s.sendRequestFailed(req.GetId(), aerr)
+		s.sendRequestFailed(stream, req.GetId(), aerr)
 		return
 	}
 
@@ -342,7 +354,7 @@ func (s *actorEventSubscription) handleInvoke(req *pb.SubscribeActorEventsRespon
 		metadata = map[string]string{contentTypeMetadataKey: ct}
 	}
 
-	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+	s.send(stream, &pb.SubscribeActorEventsRequestAlpha1{
 		RequestType: &pb.SubscribeActorEventsRequestAlpha1_InvokeResponse{
 			InvokeResponse: &pb.SubscribeActorEventsRequestInvokeResponseAlpha1{
 				Id:       req.GetId(),
@@ -364,7 +376,7 @@ func contentTypeFromMetadata(md map[string]string) string {
 	return ""
 }
 
-func (s *actorEventSubscription) handleReminder(req *pb.SubscribeActorEventsResponseReminderRequestAlpha1) {
+func (s *actorEventSubscription) handleReminder(stream pb.Dapr_SubscribeActorEventsAlpha1Client, req *pb.SubscribeActorEventsResponseReminderRequestAlpha1) {
 	// Build the same JSON shape the sidecar sends on the HTTP reminder
 	// callback, which api.ActorReminderParams unmarshals: data carries the
 	// JSON representation of the registered payload verbatim.
@@ -378,24 +390,24 @@ func (s *actorEventSubscription) handleReminder(req *pb.SubscribeActorEventsResp
 		Period:  req.GetPeriod(),
 	})
 	if err != nil {
-		s.sendRequestFailed(req.GetId(), actorErr.ErrRemindersParamsInvalid)
+		s.sendRequestFailed(stream, req.GetId(), actorErr.ErrRemindersParamsInvalid)
 		return
 	}
 
 	aerr := s.handler.InvokeReminder(s.ctx, req.GetActorType(), req.GetActorId(), req.GetName(), params)
 	if aerr != actorErr.Success {
-		s.sendRequestFailed(req.GetId(), aerr)
+		s.sendRequestFailed(stream, req.GetId(), aerr)
 		return
 	}
 
-	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+	s.send(stream, &pb.SubscribeActorEventsRequestAlpha1{
 		RequestType: &pb.SubscribeActorEventsRequestAlpha1_ReminderResponse{
 			ReminderResponse: &pb.SubscribeActorEventsRequestReminderResponseAlpha1{Id: req.GetId()},
 		},
 	})
 }
 
-func (s *actorEventSubscription) handleTimer(req *pb.SubscribeActorEventsResponseTimerRequestAlpha1) {
+func (s *actorEventSubscription) handleTimer(stream pb.Dapr_SubscribeActorEventsAlpha1Client, req *pb.SubscribeActorEventsResponseTimerRequestAlpha1) {
 	// Build the same JSON shape the sidecar sends on the HTTP timer callback,
 	// which api.ActorTimerParam unmarshals: data carries the JSON
 	// representation of the registered payload verbatim.
@@ -411,31 +423,31 @@ func (s *actorEventSubscription) handleTimer(req *pb.SubscribeActorEventsRespons
 		Period:   req.GetPeriod(),
 	})
 	if err != nil {
-		s.sendRequestFailed(req.GetId(), actorErr.ErrTimerParamsInvalid)
+		s.sendRequestFailed(stream, req.GetId(), actorErr.ErrTimerParamsInvalid)
 		return
 	}
 
 	aerr := s.handler.InvokeTimer(s.ctx, req.GetActorType(), req.GetActorId(), req.GetName(), params)
 	if aerr != actorErr.Success {
-		s.sendRequestFailed(req.GetId(), aerr)
+		s.sendRequestFailed(stream, req.GetId(), aerr)
 		return
 	}
 
-	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+	s.send(stream, &pb.SubscribeActorEventsRequestAlpha1{
 		RequestType: &pb.SubscribeActorEventsRequestAlpha1_TimerResponse{
 			TimerResponse: &pb.SubscribeActorEventsRequestReminderResponseAlpha1{Id: req.GetId()},
 		},
 	})
 }
 
-func (s *actorEventSubscription) handleDeactivate(req *pb.SubscribeActorEventsResponseDeactivateRequestAlpha1) {
+func (s *actorEventSubscription) handleDeactivate(stream pb.Dapr_SubscribeActorEventsAlpha1Client, req *pb.SubscribeActorEventsResponseDeactivateRequestAlpha1) {
 	aerr := s.handler.Deactivate(s.ctx, req.GetActorType(), req.GetActorId())
 	if aerr != actorErr.Success {
-		s.sendRequestFailed(req.GetId(), aerr)
+		s.sendRequestFailed(stream, req.GetId(), aerr)
 		return
 	}
 
-	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+	s.send(stream, &pb.SubscribeActorEventsRequestAlpha1{
 		RequestType: &pb.SubscribeActorEventsRequestAlpha1_DeactivateResponse{
 			DeactivateResponse: &pb.SubscribeActorEventsRequestDeactivateResponseAlpha1{Id: req.GetId()},
 		},
@@ -445,8 +457,8 @@ func (s *actorEventSubscription) handleDeactivate(req *pb.SubscribeActorEventsRe
 // sendRequestFailed reports a callback the handler could not process. The
 // gRPC status code matters to the sidecar: NotFound marks the failure as
 // permanent (non-retryable), e.g. an unknown actor type or method.
-func (s *actorEventSubscription) sendRequestFailed(id string, aerr actorErr.ActorErr) {
-	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+func (s *actorEventSubscription) sendRequestFailed(stream pb.Dapr_SubscribeActorEventsAlpha1Client, id string, aerr actorErr.ActorErr) {
+	s.send(stream, &pb.SubscribeActorEventsRequestAlpha1{
 		RequestType: &pb.SubscribeActorEventsRequestAlpha1_RequestFailed{
 			RequestFailed: &pb.SubscribeActorEventsRequestFailedAlpha1{
 				Id:      id,
@@ -459,11 +471,21 @@ func (s *actorEventSubscription) sendRequestFailed(id string, aerr actorErr.Acto
 
 // send serializes writes to the stream: gRPC forbids concurrent Send calls
 // on a single stream and callbacks are dispatched on separate goroutines.
-func (s *actorEventSubscription) send(msg *pb.SubscribeActorEventsRequestAlpha1) {
+// It writes to the specific stream that delivered the callback, dropping the
+// response if a reconnect has since replaced it.
+func (s *actorEventSubscription) send(stream pb.Dapr_SubscribeActorEventsAlpha1Client, msg *pb.SubscribeActorEventsRequestAlpha1) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if err := s.stream.Send(msg); err != nil && !s.closed.Load() {
+	if s.stream != stream {
+		// A reconnect replaced the stream while this callback ran. The request
+		// id is meaningless on the new stream, and the sidecar already failed
+		// the in-flight request when the old stream dropped, so drop it.
+		logger.Printf("Dropping actor event response on a reconnected stream")
+		return
+	}
+
+	if err := stream.Send(msg); err != nil && !s.closed.Load() {
 		// The response cannot be delivered (e.g. the stream dropped after the
 		// callback was dispatched); the sidecar fails the pending request on
 		// its side when the stream breaks.

--- a/client/actor_subscribe.go
+++ b/client/actor_subscribe.go
@@ -44,11 +44,6 @@ const (
 	// invoke callbacks and responses.
 	contentTypeMetadataKey = "content-type"
 
-	// actorEventsContentType is the content type of actor method responses.
-	// Actor payloads are serialized with the actor runtime codec, which is
-	// JSON by default.
-	actorEventsContentType = "application/json"
-
 	actorEventsReconnectInitialBackoff = 200 * time.Millisecond
 	actorEventsReconnectMaxBackoff     = 5 * time.Second
 )
@@ -336,15 +331,37 @@ func (s *actorEventSubscription) handleInvoke(req *pb.SubscribeActorEventsRespon
 		return
 	}
 
+	// Echo the caller's content-type back on the response. The actor runtime
+	// (de)serializes the request and response with the same per-type codec, so
+	// the request content-type describes the response payload too. daprd passes
+	// this back to the original caller verbatim; leaving it unset when the
+	// caller sent none mirrors the HTTP actor callback, which sets no explicit
+	// response content-type either.
+	var metadata map[string]string
+	if ct := contentTypeFromMetadata(req.GetMetadata()); ct != "" {
+		metadata = map[string]string{contentTypeMetadataKey: ct}
+	}
+
 	s.send(&pb.SubscribeActorEventsRequestAlpha1{
 		RequestType: &pb.SubscribeActorEventsRequestAlpha1_InvokeResponse{
 			InvokeResponse: &pb.SubscribeActorEventsRequestInvokeResponseAlpha1{
 				Id:       req.GetId(),
 				Data:     data,
-				Metadata: map[string]string{contentTypeMetadataKey: actorEventsContentType},
+				Metadata: metadata,
 			},
 		},
 	})
+}
+
+// contentTypeFromMetadata returns the content-type entry from actor callback
+// metadata, matching the key case-insensitively.
+func contentTypeFromMetadata(md map[string]string) string {
+	for k, v := range md {
+		if strings.EqualFold(k, contentTypeMetadataKey) {
+			return v
+		}
+	}
+	return ""
 }
 
 func (s *actorEventSubscription) handleReminder(req *pb.SubscribeActorEventsResponseReminderRequestAlpha1) {

--- a/client/actor_subscribe.go
+++ b/client/actor_subscribe.go
@@ -1,0 +1,549 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	actorErr "github.com/dapr/go-sdk/actor/error"
+)
+
+const (
+	// reentrancyIDMetadataKey is the metadata key under which daprd sends the
+	// reentrancy id on actor invoke callbacks. It is propagated back on
+	// outbound actor invocations performed from within the callback context.
+	reentrancyIDMetadataKey = "Dapr-Reentrancy-Id"
+
+	// contentTypeMetadataKey carries the payload content type on actor
+	// invoke callbacks and responses.
+	contentTypeMetadataKey = "content-type"
+
+	// actorEventsContentType is the content type of actor method responses.
+	// Actor payloads are serialized with the actor runtime codec, which is
+	// JSON by default.
+	actorEventsContentType = "application/json"
+
+	actorEventsReconnectInitialBackoff = 200 * time.Millisecond
+	actorEventsReconnectMaxBackoff     = 5 * time.Second
+)
+
+// ActorEventHandler dispatches actor callbacks received over the actor event
+// stream to the hosted actor implementations.
+// *actor/runtime.ActorRunTimeContext satisfies this interface.
+type ActorEventHandler interface {
+	// RegisteredActorTypes returns the actor types hosted by this handler.
+	RegisteredActorTypes() []string
+	// InvokeActorMethod invokes an actor method and returns the serialized
+	// response payload.
+	InvokeActorMethod(ctx context.Context, actorType, actorID, method string, payload []byte) ([]byte, actorErr.ActorErr)
+	// InvokeReminder invokes a reminder on an actor. params is the JSON
+	// serialized api.ActorReminderParams.
+	InvokeReminder(ctx context.Context, actorType, actorID, reminderName string, params []byte) actorErr.ActorErr
+	// InvokeTimer invokes a timer on an actor. params is the JSON serialized
+	// api.ActorTimerParam.
+	InvokeTimer(ctx context.Context, actorType, actorID, timerName string, params []byte) actorErr.ActorErr
+	// Deactivate deactivates an actor instance.
+	Deactivate(ctx context.Context, actorType, actorID string) actorErr.ActorErr
+}
+
+// ActorReentrancyConfig configures actor reentrancy for the registered actor
+// types. A nil MaxStackDepth means Dapr's default is used.
+type ActorReentrancyConfig struct {
+	Enabled       bool
+	MaxStackDepth *int32
+}
+
+// ActorEntityConfig overrides the default actor configuration for a subset of
+// the registered actor types. Zero values mean the defaults from
+// ActorEventSubscriptionOptions (or Dapr's own defaults) apply.
+type ActorEntityConfig struct {
+	Entities                []string
+	ActorIdleTimeout        time.Duration
+	DrainOngoingCallTimeout time.Duration
+	DrainRebalancedActors   *bool
+	Reentrancy              *ActorReentrancyConfig
+}
+
+// ActorEventSubscriptionOptions configures the actor registration sent to the
+// Dapr sidecar when subscribing to actor events. Zero values mean Dapr's
+// defaults are used.
+type ActorEventSubscriptionOptions struct {
+	// ActorIdleTimeout is the time an actor can stay idle before it is
+	// deactivated.
+	ActorIdleTimeout time.Duration
+	// DrainOngoingCallTimeout is how long Dapr waits for ongoing actor calls
+	// to complete when draining rebalanced actors.
+	DrainOngoingCallTimeout time.Duration
+	// DrainRebalancedActors enables draining of actors that are rebalanced to
+	// another host. A nil value means Dapr's default is used.
+	DrainRebalancedActors *bool
+	// Reentrancy configures actor reentrancy for the registered actor types.
+	Reentrancy *ActorReentrancyConfig
+	// EntitiesConfig overrides the defaults above for specific actor types.
+	EntitiesConfig []ActorEntityConfig
+}
+
+// actorEventSubscription hosts actor types over the app-initiated
+// SubscribeActorEventsAlpha1 stream, dispatching callbacks pushed by the
+// sidecar to the ActorEventHandler and sending the correlated responses back.
+type actorEventSubscription struct {
+	ctx     context.Context
+	handler ActorEventHandler
+
+	// lock locks concurrent writes to the subscription stream.
+	lock   sync.Mutex
+	stream pb.Dapr_SubscribeActorEventsAlpha1Client
+	closed atomic.Bool
+
+	createStream func(ctx context.Context) (pb.Dapr_SubscribeActorEventsAlpha1Client, error)
+}
+
+// SubscribeActorEvents registers the handler's actor types with the Dapr
+// sidecar and hosts them over a bidirectional event stream: actor method
+// invocations, reminders, timers, and deactivations are delivered through the
+// stream, so the application does not need to expose a server port for actor
+// callbacks. The stream automatically reconnects and re-registers on
+// transient failures.
+//
+// Hosting stops when the returned stop function is called or ctx is
+// cancelled. Actor types must be registered on the handler (e.g. with
+// runtime.ActorRunTimeContext.RegisterActorFactory) before subscribing.
+//
+// This API is currently in Alpha.
+func (c *GRPCClient) SubscribeActorEvents(ctx context.Context, handler ActorEventHandler, opts ActorEventSubscriptionOptions) (func() error, error) {
+	if handler == nil {
+		return nil, errors.New("actor event handler required")
+	}
+	if len(handler.RegisteredActorTypes()) == 0 {
+		return nil, errors.New("actor event handler has no registered actor types")
+	}
+
+	createStream := func(ctx context.Context) (pb.Dapr_SubscribeActorEventsAlpha1Client, error) {
+		// Resolve the actor types on every (re)connect so types registered
+		// after a disconnect are picked up on re-registration.
+		return c.subscribeActorEventsInitialRequest(ctx, handler.RegisteredActorTypes(), opts)
+	}
+
+	stream, err := createStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &actorEventSubscription{
+		ctx:          ctx,
+		handler:      handler,
+		stream:       stream,
+		createStream: createStream,
+	}
+
+	go s.run()
+
+	return s.Close, nil
+}
+
+// subscribeActorEventsInitialRequest opens the actor events stream, sends the
+// initial registration message and waits for the registration ack.
+func (c *GRPCClient) subscribeActorEventsInitialRequest(ctx context.Context, entities []string, opts ActorEventSubscriptionOptions) (pb.Dapr_SubscribeActorEventsAlpha1Client, error) {
+	stream, err := c.protoClient.SubscribeActorEventsAlpha1(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = stream.Send(&pb.SubscribeActorEventsRequestAlpha1{
+		RequestType: &pb.SubscribeActorEventsRequestAlpha1_InitialRequest{
+			InitialRequest: actorEventsInitialRequest(entities, opts),
+		},
+	})
+	if err != nil {
+		return nil, errors.Join(err, stream.CloseSend())
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, errors.Join(err, stream.CloseSend())
+	}
+
+	if resp.GetInitialResponse() == nil {
+		return nil, fmt.Errorf("unexpected initial response from server: %v", resp)
+	}
+
+	return stream, nil
+}
+
+// actorEventsInitialRequest maps the registered actor types and subscription
+// options to the wire-level registration message. Unset options are left nil
+// so Dapr applies its own defaults.
+func actorEventsInitialRequest(entities []string, opts ActorEventSubscriptionOptions) *pb.SubscribeActorEventsRequestInitialAlpha1 {
+	req := &pb.SubscribeActorEventsRequestInitialAlpha1{
+		Entities:                entities,
+		ActorIdleTimeout:        optionalDuration(opts.ActorIdleTimeout),
+		DrainOngoingCallTimeout: optionalDuration(opts.DrainOngoingCallTimeout),
+		DrainRebalancedActors:   opts.DrainRebalancedActors,
+		Reentrancy:              opts.Reentrancy.proto(),
+	}
+	for _, ec := range opts.EntitiesConfig {
+		req.EntitiesConfig = append(req.EntitiesConfig, &pb.ActorEntityConfig{
+			Entities:                ec.Entities,
+			ActorIdleTimeout:        optionalDuration(ec.ActorIdleTimeout),
+			DrainOngoingCallTimeout: optionalDuration(ec.DrainOngoingCallTimeout),
+			DrainRebalancedActors:   ec.DrainRebalancedActors,
+			Reentrancy:              ec.Reentrancy.proto(),
+		})
+	}
+	return req
+}
+
+func (r *ActorReentrancyConfig) proto() *pb.ActorReentrancyConfig {
+	if r == nil {
+		return nil
+	}
+	return &pb.ActorReentrancyConfig{
+		Enabled:       r.Enabled,
+		MaxStackDepth: r.MaxStackDepth,
+	}
+}
+
+func optionalDuration(d time.Duration) *durationpb.Duration {
+	if d == 0 {
+		return nil
+	}
+	return durationpb.New(d)
+}
+
+// Close stops hosting actor events and closes the stream.
+func (s *actorEventSubscription) Close() error {
+	if !s.closed.CompareAndSwap(false, true) {
+		return errors.New("actor event subscription already closed")
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.stream != nil {
+		return s.stream.CloseSend()
+	}
+	return nil
+}
+
+// run reads callbacks from the stream and dispatches each on its own
+// goroutine so the read loop keeps draining. On a transient stream error it
+// reconnects with a backoff, re-sending the initial registration.
+func (s *actorEventSubscription) run() {
+	for {
+		msg, err := s.stream.Recv()
+		if err != nil {
+			if s.closed.Load() || s.ctx.Err() != nil {
+				return
+			}
+
+			if st, ok := status.FromError(err); ok && st.Code() == codes.Canceled {
+				return
+			}
+
+			logger.Printf("Error receiving actor events, reconnecting: %v", err)
+			if !s.reconnect() {
+				return
+			}
+			continue
+		}
+
+		go s.dispatch(msg)
+	}
+}
+
+// reconnect re-establishes the actor events stream with an exponential
+// backoff, returning false when the subscription is closed or its context is
+// cancelled.
+func (s *actorEventSubscription) reconnect() bool {
+	backoff := actorEventsReconnectInitialBackoff
+	for {
+		select {
+		case <-s.ctx.Done():
+			return false
+		case <-time.After(backoff):
+		}
+		if s.closed.Load() {
+			return false
+		}
+
+		newStream, err := s.createStream(s.ctx)
+		if err != nil {
+			logger.Printf("Error reconnecting actor events stream, retrying in %s: %v", backoff, err)
+			backoff = min(backoff*2, actorEventsReconnectMaxBackoff)
+			continue
+		}
+
+		s.lock.Lock()
+		s.stream = newStream
+		s.lock.Unlock()
+
+		return true
+	}
+}
+
+// dispatch routes a single callback pushed by the sidecar to the handler and
+// sends the correlated response, echoing the request id.
+func (s *actorEventSubscription) dispatch(msg *pb.SubscribeActorEventsResponseAlpha1) {
+	switch t := msg.GetResponseType().(type) {
+	case *pb.SubscribeActorEventsResponseAlpha1_InvokeRequest:
+		s.handleInvoke(t.InvokeRequest)
+	case *pb.SubscribeActorEventsResponseAlpha1_ReminderRequest:
+		s.handleReminder(t.ReminderRequest)
+	case *pb.SubscribeActorEventsResponseAlpha1_TimerRequest:
+		s.handleTimer(t.TimerRequest)
+	case *pb.SubscribeActorEventsResponseAlpha1_DeactivateRequest:
+		s.handleDeactivate(t.DeactivateRequest)
+	default:
+		logger.Printf("Unexpected actor event message type: %T", t)
+	}
+}
+
+func (s *actorEventSubscription) handleInvoke(req *pb.SubscribeActorEventsResponseInvokeRequestAlpha1) {
+	// Make the callback metadata (content-type, Dapr-Reentrancy-Id, ...)
+	// available to the actor code: InvokeActor propagates the reentrancy id
+	// from this context on outbound actor invocations.
+	ctx := withActorCallbackMetadata(s.ctx, req.GetMetadata())
+
+	data, aerr := s.handler.InvokeActorMethod(ctx, req.GetActorType(), req.GetActorId(), req.GetMethod(), req.GetData())
+	if aerr != actorErr.Success {
+		s.sendRequestFailed(req.GetId(), aerr)
+		return
+	}
+
+	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+		RequestType: &pb.SubscribeActorEventsRequestAlpha1_InvokeResponse{
+			InvokeResponse: &pb.SubscribeActorEventsRequestInvokeResponseAlpha1{
+				Id:       req.GetId(),
+				Data:     data,
+				Metadata: map[string]string{contentTypeMetadataKey: actorEventsContentType},
+			},
+		},
+	})
+}
+
+func (s *actorEventSubscription) handleReminder(req *pb.SubscribeActorEventsResponseReminderRequestAlpha1) {
+	// Build the same JSON shape the sidecar sends on the HTTP reminder
+	// callback, which api.ActorReminderParams unmarshals: data carries the
+	// JSON representation of the registered payload verbatim.
+	params, err := json.Marshal(&struct {
+		Data    json.RawMessage `json:"data,omitempty"`
+		DueTime string          `json:"dueTime"`
+		Period  string          `json:"period"`
+	}{
+		Data:    anyToRawData(req.GetData()),
+		DueTime: req.GetDueTime(),
+		Period:  req.GetPeriod(),
+	})
+	if err != nil {
+		s.sendRequestFailed(req.GetId(), actorErr.ErrRemindersParamsInvalid)
+		return
+	}
+
+	aerr := s.handler.InvokeReminder(s.ctx, req.GetActorType(), req.GetActorId(), req.GetName(), params)
+	if aerr != actorErr.Success {
+		s.sendRequestFailed(req.GetId(), aerr)
+		return
+	}
+
+	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+		RequestType: &pb.SubscribeActorEventsRequestAlpha1_ReminderResponse{
+			ReminderResponse: &pb.SubscribeActorEventsRequestReminderResponseAlpha1{Id: req.GetId()},
+		},
+	})
+}
+
+func (s *actorEventSubscription) handleTimer(req *pb.SubscribeActorEventsResponseTimerRequestAlpha1) {
+	// Build the same JSON shape the sidecar sends on the HTTP timer callback,
+	// which api.ActorTimerParam unmarshals: data carries the JSON
+	// representation of the registered payload verbatim.
+	params, err := json.Marshal(&struct {
+		Callback string          `json:"callback"`
+		Data     json.RawMessage `json:"data,omitempty"`
+		DueTime  string          `json:"dueTime"`
+		Period   string          `json:"period"`
+	}{
+		Callback: req.GetCallback(),
+		Data:     anyToRawData(req.GetData()),
+		DueTime:  req.GetDueTime(),
+		Period:   req.GetPeriod(),
+	})
+	if err != nil {
+		s.sendRequestFailed(req.GetId(), actorErr.ErrTimerParamsInvalid)
+		return
+	}
+
+	aerr := s.handler.InvokeTimer(s.ctx, req.GetActorType(), req.GetActorId(), req.GetName(), params)
+	if aerr != actorErr.Success {
+		s.sendRequestFailed(req.GetId(), aerr)
+		return
+	}
+
+	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+		RequestType: &pb.SubscribeActorEventsRequestAlpha1_TimerResponse{
+			TimerResponse: &pb.SubscribeActorEventsRequestReminderResponseAlpha1{Id: req.GetId()},
+		},
+	})
+}
+
+func (s *actorEventSubscription) handleDeactivate(req *pb.SubscribeActorEventsResponseDeactivateRequestAlpha1) {
+	aerr := s.handler.Deactivate(s.ctx, req.GetActorType(), req.GetActorId())
+	if aerr != actorErr.Success {
+		s.sendRequestFailed(req.GetId(), aerr)
+		return
+	}
+
+	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+		RequestType: &pb.SubscribeActorEventsRequestAlpha1_DeactivateResponse{
+			DeactivateResponse: &pb.SubscribeActorEventsRequestDeactivateResponseAlpha1{Id: req.GetId()},
+		},
+	})
+}
+
+// sendRequestFailed reports a callback the handler could not process. The
+// gRPC status code matters to the sidecar: NotFound marks the failure as
+// permanent (non-retryable), e.g. an unknown actor type or method.
+func (s *actorEventSubscription) sendRequestFailed(id string, aerr actorErr.ActorErr) {
+	s.send(&pb.SubscribeActorEventsRequestAlpha1{
+		RequestType: &pb.SubscribeActorEventsRequestAlpha1_RequestFailed{
+			RequestFailed: &pb.SubscribeActorEventsRequestFailedAlpha1{
+				Id:      id,
+				Code:    uint32(actorErrToStatusCode(aerr)),
+				Message: actorErrMessage(aerr),
+			},
+		},
+	})
+}
+
+// send serializes writes to the stream: gRPC forbids concurrent Send calls
+// on a single stream and callbacks are dispatched on separate goroutines.
+func (s *actorEventSubscription) send(msg *pb.SubscribeActorEventsRequestAlpha1) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if err := s.stream.Send(msg); err != nil && !s.closed.Load() {
+		// The response cannot be delivered (e.g. the stream dropped after the
+		// callback was dispatched); the sidecar fails the pending request on
+		// its side when the stream breaks.
+		logger.Printf("Error sending actor event response: %v", err)
+	}
+}
+
+// actorErrToStatusCode maps actor runtime errors to the gRPC status codes
+// reported on request_failed messages. The mapping mirrors the HTTP actor
+// service, where *NotFound errors map to 404 and the rest to 500.
+func actorErrToStatusCode(aerr actorErr.ActorErr) codes.Code {
+	switch aerr {
+	case actorErr.ErrActorTypeNotFound,
+		actorErr.ErrActorMethodNoFound,
+		actorErr.ErrActorIDNotFound,
+		actorErr.ErrReminderFuncUndefined:
+		return codes.NotFound
+	case actorErr.ErrRemindersParamsInvalid,
+		actorErr.ErrTimerParamsInvalid:
+		return codes.InvalidArgument
+	default:
+		return codes.Internal
+	}
+}
+
+func actorErrMessage(aerr actorErr.ActorErr) string {
+	switch aerr {
+	case actorErr.ErrActorTypeNotFound:
+		return "actor type not found"
+	case actorErr.ErrActorMethodNoFound:
+		return "actor method not found"
+	case actorErr.ErrActorIDNotFound:
+		return "actor id not found"
+	case actorErr.ErrReminderFuncUndefined:
+		return "actor does not implement reminder callbacks"
+	case actorErr.ErrRemindersParamsInvalid:
+		return "invalid reminder parameters"
+	case actorErr.ErrTimerParamsInvalid:
+		return "invalid timer parameters"
+	case actorErr.ErrActorMethodSerializeFailed:
+		return "failed to serialize actor method payload"
+	case actorErr.ErrActorInvokeFailed:
+		return "actor method invocation failed"
+	case actorErr.ErrActorFactoryNotSet:
+		return "actor factory not set"
+	case actorErr.ErrSaveStateFailed:
+		return "failed to save actor state"
+	default:
+		return fmt.Sprintf("actor error %d", aerr)
+	}
+}
+
+// anyToRawData unwraps the reminder/timer payload the sidecar sends as a
+// google.protobuf.Any. Payloads registered as raw bytes (the common case)
+// arrive as a wrapped BytesValue; typed payloads are rendered as JSON. This
+// mirrors how the sidecar serializes reminder data for the HTTP callbacks.
+func anyToRawData(data *anypb.Any) []byte {
+	if data == nil {
+		return nil
+	}
+	msg, err := data.UnmarshalNew()
+	if err != nil {
+		// Unknown or unregistered payload type: fall back to the raw value.
+		return data.GetValue()
+	}
+	if b, ok := msg.(*wrapperspb.BytesValue); ok {
+		return b.GetValue()
+	}
+	d, err := protojson.Marshal(msg)
+	if err != nil {
+		return data.GetValue()
+	}
+	return d
+}
+
+// actorCallbackMetadataCtxKey carries the metadata of the actor callback
+// being processed on the context handed to actor code.
+type actorCallbackMetadataCtxKey struct{}
+
+func withActorCallbackMetadata(ctx context.Context, md map[string]string) context.Context {
+	if len(md) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, actorCallbackMetadataCtxKey{}, md)
+}
+
+// reentrancyIDFromContext returns the reentrancy id of the actor callback in
+// flight on this context, if any.
+func reentrancyIDFromContext(ctx context.Context) (string, bool) {
+	md, ok := ctx.Value(actorCallbackMetadataCtxKey{}).(map[string]string)
+	if !ok {
+		return "", false
+	}
+	for k, v := range md {
+		if strings.EqualFold(k, reentrancyIDMetadataKey) && v != "" {
+			return v, true
+		}
+	}
+	return "", false
+}

--- a/client/actor_subscribe.go
+++ b/client/actor_subscribe.go
@@ -32,6 +32,7 @@ import (
 
 	pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	actorErr "github.com/dapr/go-sdk/actor/error"
+	"github.com/dapr/kit/events/loop"
 )
 
 const (
@@ -46,7 +47,28 @@ const (
 
 	actorEventsReconnectInitialBackoff = 200 * time.Millisecond
 	actorEventsReconnectMaxBackoff     = 5 * time.Second
+
+	// actorEventsSendBuffer is the per-segment capacity of the outbound send
+	// loop's queue. The queue grows by segments under burst, so this only sets
+	// how often that happens.
+	actorEventsSendBuffer = 64
 )
+
+// actorEventsSendLoopFactory builds the single-consumer loop that serializes
+// outbound writes to the stream. gRPC forbids concurrent Send on one stream;
+// running every write through one loop goroutine serializes them without
+// holding a lock across the (potentially blocking) Send. Mirrors the
+// loop-per-stream pattern daprd uses for its own actor streams.
+var actorEventsSendLoopFactory = loop.New[actorEventOutbound](actorEventsSendBuffer)
+
+// actorEventOutbound is a single write to perform on the actor event stream,
+// bound to the stream that produced the originating callback so a response
+// left over from a stream that has since reconnected can be dropped. A nil msg
+// is the loop's close sentinel.
+type actorEventOutbound struct {
+	stream pb.Dapr_SubscribeActorEventsAlpha1Client
+	msg    *pb.SubscribeActorEventsRequestAlpha1
+}
 
 // ActorEventHandler dispatches actor callbacks received over the actor event
 // stream to the hosted actor implementations.
@@ -115,7 +137,11 @@ type actorEventSubscription struct {
 
 	handler ActorEventHandler
 
-	// lock locks concurrent writes to the subscription stream.
+	// sendLoop serializes all writes to the stream on a single goroutine, so a
+	// blocking Send never stalls the read loop or the dispatch goroutines.
+	sendLoop loop.Interface[actorEventOutbound]
+
+	// lock guards the stream pointer, which reconnect replaces.
 	lock   sync.Mutex
 	stream pb.Dapr_SubscribeActorEventsAlpha1Client
 	closed atomic.Bool
@@ -166,7 +192,9 @@ func (c *GRPCClient) SubscribeActorEvents(ctx context.Context, handler ActorEven
 		stream:       stream,
 		createStream: createStream,
 	}
+	s.sendLoop = actorEventsSendLoopFactory.NewLoop(s)
 
+	go func() { _ = s.sendLoop.Run(streamCtx) }()
 	go s.run()
 
 	return s.Close, nil
@@ -244,33 +272,32 @@ func optionalDuration(d time.Duration) *durationpb.Duration {
 	return durationpb.New(d)
 }
 
-// Close stops hosting actor events and closes the stream.
+// Close stops hosting actor events. Cancelling the stream context tears down
+// the stream (unblocking a Recv in run() and any Send in the loop), then the
+// send loop is drained and stopped. No lock is taken, so a blocked Send cannot
+// deadlock shutdown.
 func (s *actorEventSubscription) Close() error {
 	if !s.closed.CompareAndSwap(false, true) {
 		return errors.New("actor event subscription already closed")
 	}
 
-	// Half-close the send side first, then cancel the stream context so a Recv
-	// blocked in run() unblocks promptly instead of waiting for the server to
-	// react to the half-close.
-	s.lock.Lock()
-	var err error
-	if s.stream != nil {
-		err = s.stream.CloseSend()
-	}
-	s.lock.Unlock()
-
 	s.cancel()
-	return err
+	s.sendLoop.Close(actorEventOutbound{})
+	return nil
 }
 
 // run reads callbacks from the stream and dispatches each on its own
 // goroutine so the read loop keeps draining. On a transient stream error it
 // reconnects with a backoff, re-sending the initial registration.
 func (s *actorEventSubscription) run() {
+	// Ensure the send loop is stopped when the reader exits, including when the
+	// caller cancels ctx without calling the returned stop func. Close is
+	// idempotent, so a concurrent stop() is harmless.
+	defer s.Close() //nolint:errcheck
+
 	for {
 		// Snapshot the current stream under the lock; reconnect may replace it
-		// concurrently with the send goroutines below.
+		// concurrently with the send loop.
 		s.lock.Lock()
 		stream := s.stream
 		s.lock.Unlock()
@@ -484,28 +511,42 @@ func (s *actorEventSubscription) sendRequestFailed(stream pb.Dapr_SubscribeActor
 	})
 }
 
-// send serializes writes to the stream: gRPC forbids concurrent Send calls
-// on a single stream and callbacks are dispatched on separate goroutines.
-// It writes to the specific stream that delivered the callback, dropping the
-// response if a reconnect has since replaced it.
+// send queues a write to the stream. Enqueue is non-blocking, so dispatch
+// goroutines never block here; the send loop performs the actual write.
 func (s *actorEventSubscription) send(stream pb.Dapr_SubscribeActorEventsAlpha1Client, msg *pb.SubscribeActorEventsRequestAlpha1) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.sendLoop.Enqueue(actorEventOutbound{stream: stream, msg: msg})
+}
 
-	if s.stream != stream {
+// Handle performs one queued write on the send loop's single goroutine, which
+// serializes Send as gRPC requires without holding a lock across it. It writes
+// to the specific stream that delivered the callback, dropping the response if
+// a reconnect has since replaced the stream. A nil msg is the close sentinel.
+func (s *actorEventSubscription) Handle(_ context.Context, out actorEventOutbound) error {
+	if out.msg == nil {
+		return nil
+	}
+
+	s.lock.Lock()
+	current := s.stream
+	s.lock.Unlock()
+
+	if out.stream != current {
 		// A reconnect replaced the stream while this callback ran. The request
 		// id is meaningless on the new stream, and the sidecar already failed
 		// the in-flight request when the old stream dropped, so drop it.
 		logger.Printf("Dropping actor event response on a reconnected stream")
-		return
+		return nil
 	}
 
-	if err := stream.Send(msg); err != nil && !s.closed.Load() {
+	if err := out.stream.Send(out.msg); err != nil && !s.closed.Load() {
 		// The response cannot be delivered (e.g. the stream dropped after the
 		// callback was dispatched); the sidecar fails the pending request on
 		// its side when the stream breaks.
 		logger.Printf("Error sending actor event response: %v", err)
 	}
+	// Never return an error: that would stop the loop and abort all further
+	// writes for this subscription.
+	return nil
 }
 
 // actorErrToStatusCode maps actor runtime errors to the gRPC status codes

--- a/client/actor_subscribe_test.go
+++ b/client/actor_subscribe_test.go
@@ -509,6 +509,75 @@ func TestSubscribeActorEventsReconnect(t *testing.T) {
 	assert.Equal(t, "1", resp.GetInvokeResponse().GetId())
 }
 
+// TestSubscribeActorEventsResponseDroppedAfterReconnect verifies that a
+// callback still running when the stream reconnects has its response dropped
+// rather than sent on the new stream, where the request id would not
+// correlate with any pending request.
+func TestSubscribeActorEventsResponseDroppedAfterReconnect(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	handler := &testActorEventHandler{
+		actorTypes: []string{"testActorType"},
+		invokeFn: func(ctx context.Context, actorType, actorID, method string, payload []byte) ([]byte, actorErr.ActorErr) {
+			if method == "Blocking" {
+				close(entered)
+				<-release // hold the response until after the reconnect
+			}
+			return payload, actorErr.Success
+		},
+	}
+
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	recvWithTimeout(t, srv.initialRequests)
+	session := recvWithTimeout(t, srv.sessions)
+
+	// Deliver a callback that blocks inside the handler, capturing the
+	// original stream.
+	session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+		ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+			InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+				Id: "stale", ActorType: "testActorType", ActorId: "myactor", Method: "Blocking",
+			},
+		},
+	})
+	<-entered
+
+	// Reconnect while the handler is still running.
+	session.kill(status.Error(codes.Unavailable, "sidecar restarting"))
+	recvWithTimeout(t, srv.initialRequests)
+	newSession := recvWithTimeout(t, srv.sessions)
+
+	// Let the stale handler finish: its response targets the old stream and
+	// must be dropped, never reaching the new stream.
+	close(release)
+
+	// A fresh callback on the new stream still works.
+	newSession.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+		ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+			InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+				Id: "fresh", ActorType: "testActorType", ActorId: "myactor", Method: "Echo",
+			},
+		},
+	})
+
+	resp := recvWithTimeout(t, newSession.responses)
+	require.NotNil(t, resp.GetInvokeResponse())
+	assert.Equal(t, "fresh", resp.GetInvokeResponse().GetId(),
+		"the new stream must only receive the fresh response, not the stale one")
+
+	// No further (stale) response should arrive on the new stream.
+	select {
+	case extra := <-newSession.responses:
+		t.Fatalf("unexpected extra response on reconnected stream: %v", extra)
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
 func TestSubscribeActorEventsStop(t *testing.T) {
 	srv, client := newTestActorEventsServer(t)
 

--- a/client/actor_subscribe_test.go
+++ b/client/actor_subscribe_test.go
@@ -159,6 +159,43 @@ func TestSubscribeActorEventsInvoke(t *testing.T) {
 		assert.Equal(t, "reentrancy-id-1", id)
 	})
 
+	t.Run("response echoes a non-json content-type", func(t *testing.T) {
+		// The content-type must reflect the caller's, not a hardcoded JSON:
+		// the actor runtime supports non-JSON serializers.
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+				InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+					Id:        "ct",
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+					Method:    "GetUser",
+					Metadata:  map[string]string{"content-type": "application/x-yaml"},
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		require.NotNil(t, resp.GetInvokeResponse())
+		assert.Equal(t, "application/x-yaml", resp.GetInvokeResponse().GetMetadata()["content-type"])
+	})
+
+	t.Run("response omits content-type when the caller sent none", func(t *testing.T) {
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+				InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+					Id:        "no-ct",
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+					Method:    "GetUser",
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		require.NotNil(t, resp.GetInvokeResponse())
+		assert.Empty(t, resp.GetInvokeResponse().GetMetadata())
+	})
+
 	t.Run("method not found", func(t *testing.T) {
 		handler.setInvokeErr(actorErr.ErrActorMethodNoFound)
 

--- a/client/actor_subscribe_test.go
+++ b/client/actor_subscribe_test.go
@@ -638,12 +638,20 @@ func Test_anyToRawData(t *testing.T) {
 		assert.Equal(t, []byte(`"hello"`), anyToRawData(data))
 	})
 
-	t.Run("unknown type falls back to raw value", func(t *testing.T) {
+	t.Run("unknown type falls back to a valid JSON string", func(t *testing.T) {
 		data := &anypb.Any{
 			TypeUrl: "type.googleapis.com/unknown.Type",
 			Value:   []byte("raw"),
 		}
-		assert.Equal(t, []byte("raw"), anyToRawData(data))
+		got := anyToRawData(data)
+
+		// The fallback must be valid JSON (it is embedded as json.RawMessage in
+		// the reminder/timer params) and must round-trip back to the raw bytes,
+		// matching how api.ActorReminderParams.Data ([]byte) decodes it.
+		assert.True(t, json.Valid(got), "fallback must be valid JSON: %s", got)
+		var decoded []byte
+		require.NoError(t, json.Unmarshal(got, &decoded))
+		assert.Equal(t, []byte("raw"), decoded)
 	})
 }
 

--- a/client/actor_subscribe_test.go
+++ b/client/actor_subscribe_test.go
@@ -1,0 +1,811 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/go-sdk/actor/api"
+	actorErr "github.com/dapr/go-sdk/actor/error"
+)
+
+const testActorEventsTimeout = 5 * time.Second
+
+func TestSubscribeActorEventsValidation(t *testing.T) {
+	_, client := newTestActorEventsServer(t)
+
+	t.Run("nil handler", func(t *testing.T) {
+		_, err := client.SubscribeActorEvents(t.Context(), nil, ActorEventSubscriptionOptions{})
+		require.Error(t, err)
+	})
+
+	t.Run("no registered actor types", func(t *testing.T) {
+		handler := &testActorEventHandler{}
+		_, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+		require.Error(t, err)
+	})
+}
+
+func TestSubscribeActorEventsInitialRequest(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	drain := true
+	maxStackDepth := int32(16)
+	handler := &testActorEventHandler{actorTypes: []string{"testActorType", "otherActorType"}}
+
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{
+		ActorIdleTimeout:        time.Hour,
+		DrainOngoingCallTimeout: 30 * time.Second,
+		DrainRebalancedActors:   &drain,
+		Reentrancy: &ActorReentrancyConfig{
+			Enabled:       true,
+			MaxStackDepth: &maxStackDepth,
+		},
+		EntitiesConfig: []ActorEntityConfig{{
+			Entities:         []string{"otherActorType"},
+			ActorIdleTimeout: time.Minute,
+		}},
+	})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	initial := recvWithTimeout(t, srv.initialRequests)
+	assert.Equal(t, []string{"testActorType", "otherActorType"}, initial.GetEntities())
+	assert.Equal(t, time.Hour, initial.GetActorIdleTimeout().AsDuration())
+	assert.Equal(t, 30*time.Second, initial.GetDrainOngoingCallTimeout().AsDuration())
+	assert.True(t, initial.GetDrainRebalancedActors())
+	require.NotNil(t, initial.GetReentrancy())
+	assert.True(t, initial.GetReentrancy().GetEnabled())
+	assert.Equal(t, int32(16), initial.GetReentrancy().GetMaxStackDepth())
+	require.Len(t, initial.GetEntitiesConfig(), 1)
+	assert.Equal(t, []string{"otherActorType"}, initial.GetEntitiesConfig()[0].GetEntities())
+	assert.Equal(t, time.Minute, initial.GetEntitiesConfig()[0].GetActorIdleTimeout().AsDuration())
+	assert.Nil(t, initial.GetEntitiesConfig()[0].GetReentrancy())
+}
+
+func TestSubscribeActorEventsInitialRequestDefaults(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	handler := &testActorEventHandler{actorTypes: []string{"testActorType"}}
+
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	initial := recvWithTimeout(t, srv.initialRequests)
+	assert.Equal(t, []string{"testActorType"}, initial.GetEntities())
+	assert.Nil(t, initial.GetActorIdleTimeout())
+	assert.Nil(t, initial.GetDrainOngoingCallTimeout())
+	assert.Nil(t, initial.DrainRebalancedActors)
+	assert.Nil(t, initial.GetReentrancy())
+	assert.Empty(t, initial.GetEntitiesConfig())
+}
+
+func TestSubscribeActorEventsInvoke(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	handler := &testActorEventHandler{actorTypes: []string{"testActorType"}}
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	session := recvWithTimeout(t, srv.sessions)
+
+	t.Run("success", func(t *testing.T) {
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+				InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+					Id:        "1",
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+					Method:    "GetUser",
+					Data:      []byte(`{"name":"test"}`),
+					Metadata: map[string]string{
+						"content-type":          "application/json",
+						"Dapr-Reentrancy-Id":    "reentrancy-id-1",
+						"X-Custom-Header-Value": "custom",
+					},
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		invokeResp := resp.GetInvokeResponse()
+		require.NotNil(t, invokeResp)
+		assert.Equal(t, "1", invokeResp.GetId())
+		assert.Equal(t, []byte(`{"name":"test"}`), invokeResp.GetData())
+		assert.Equal(t, "application/json", invokeResp.GetMetadata()["content-type"])
+
+		calls := handler.invokeCalls()
+		require.Len(t, calls, 1)
+		assert.Equal(t, "testActorType", calls[0].actorType)
+		assert.Equal(t, "myactor", calls[0].actorID)
+		assert.Equal(t, "GetUser", calls[0].method)
+		assert.Equal(t, []byte(`{"name":"test"}`), calls[0].payload)
+
+		// The reentrancy id from the callback metadata must be available on
+		// the handler context for propagation on outbound actor invocations.
+		id, ok := reentrancyIDFromContext(calls[0].ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "reentrancy-id-1", id)
+	})
+
+	t.Run("method not found", func(t *testing.T) {
+		handler.setInvokeErr(actorErr.ErrActorMethodNoFound)
+
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+				InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+					Id:        "2",
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+					Method:    "Missing",
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		failed := resp.GetRequestFailed()
+		require.NotNil(t, failed)
+		assert.Equal(t, "2", failed.GetId())
+		assert.Equal(t, uint32(codes.NotFound), failed.GetCode())
+		assert.NotEmpty(t, failed.GetMessage())
+	})
+
+	t.Run("invocation failed", func(t *testing.T) {
+		handler.setInvokeErr(actorErr.ErrActorInvokeFailed)
+
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+				InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+					Id:        "3",
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+					Method:    "GetUser",
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		failed := resp.GetRequestFailed()
+		require.NotNil(t, failed)
+		assert.Equal(t, "3", failed.GetId())
+		assert.Equal(t, uint32(codes.Internal), failed.GetCode())
+	})
+}
+
+func TestSubscribeActorEventsReminder(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	handler := &testActorEventHandler{actorTypes: []string{"testActorType"}}
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	session := recvWithTimeout(t, srv.sessions)
+
+	t.Run("success", func(t *testing.T) {
+		// The sidecar stores reminder data registered through
+		// RegisterActorReminder as its JSON representation, wrapped in a
+		// BytesValue Any on the stream.
+		registered := []byte(`"reminderdata"`)
+		jsonData, err := json.Marshal(registered)
+		require.NoError(t, err)
+		data, err := anypb.New(wrapperspb.Bytes(jsonData))
+		require.NoError(t, err)
+
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_ReminderRequest{
+				ReminderRequest: &pb.SubscribeActorEventsResponseReminderRequestAlpha1{
+					Id:        "10",
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+					Name:      "myreminder",
+					DueTime:   "5s",
+					Period:    "10s",
+					Data:      data,
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		reminderResp := resp.GetReminderResponse()
+		require.NotNil(t, reminderResp)
+		assert.Equal(t, "10", reminderResp.GetId())
+		assert.False(t, reminderResp.GetCancel())
+
+		calls := handler.reminderCalls()
+		require.Len(t, calls, 1)
+		assert.Equal(t, "testActorType", calls[0].actorType)
+		assert.Equal(t, "myactor", calls[0].actorID)
+		assert.Equal(t, "myreminder", calls[0].name)
+
+		// The actor runtime must receive the same params shape as the HTTP
+		// reminder callback, round-tripping the registered data unchanged.
+		var params api.ActorReminderParams
+		require.NoError(t, json.Unmarshal(calls[0].params, &params))
+		assert.Equal(t, registered, params.Data)
+		assert.Equal(t, "5s", params.DueTime)
+		assert.Equal(t, "10s", params.Period)
+	})
+
+	t.Run("reminder callee not implemented", func(t *testing.T) {
+		handler.setReminderErr(actorErr.ErrReminderFuncUndefined)
+
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_ReminderRequest{
+				ReminderRequest: &pb.SubscribeActorEventsResponseReminderRequestAlpha1{
+					Id:        "11",
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+					Name:      "myreminder",
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		failed := resp.GetRequestFailed()
+		require.NotNil(t, failed)
+		assert.Equal(t, "11", failed.GetId())
+		assert.Equal(t, uint32(codes.NotFound), failed.GetCode())
+	})
+}
+
+func TestSubscribeActorEventsTimer(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	handler := &testActorEventHandler{actorTypes: []string{"testActorType"}}
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	session := recvWithTimeout(t, srv.sessions)
+
+	// The sidecar stores timer data registered through RegisterActorTimer as
+	// its JSON representation, wrapped in a BytesValue Any on the stream.
+	registered := []byte(`"timerdata"`)
+	jsonData, err := json.Marshal(registered)
+	require.NoError(t, err)
+	data, err := anypb.New(wrapperspb.Bytes(jsonData))
+	require.NoError(t, err)
+
+	session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+		ResponseType: &pb.SubscribeActorEventsResponseAlpha1_TimerRequest{
+			TimerRequest: &pb.SubscribeActorEventsResponseTimerRequestAlpha1{
+				Id:        "20",
+				ActorType: "testActorType",
+				ActorId:   "myactor",
+				Name:      "mytimer",
+				DueTime:   "5s",
+				Period:    "10s",
+				Callback:  "Invoke",
+				Data:      data,
+			},
+		},
+	})
+
+	resp := recvWithTimeout(t, session.responses)
+	timerResp := resp.GetTimerResponse()
+	require.NotNil(t, timerResp)
+	assert.Equal(t, "20", timerResp.GetId())
+	assert.False(t, timerResp.GetCancel())
+
+	calls := handler.timerCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "mytimer", calls[0].name)
+
+	// The actor runtime must receive the same params shape as the HTTP timer
+	// callback, round-tripping the registered data unchanged.
+	var params api.ActorTimerParam
+	require.NoError(t, json.Unmarshal(calls[0].params, &params))
+	assert.Equal(t, "Invoke", params.CallBack)
+	assert.Equal(t, registered, params.Data)
+	assert.Equal(t, "5s", params.DueTime)
+	assert.Equal(t, "10s", params.Period)
+}
+
+func TestSubscribeActorEventsDeactivate(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	handler := &testActorEventHandler{actorTypes: []string{"testActorType"}}
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	session := recvWithTimeout(t, srv.sessions)
+
+	t.Run("success", func(t *testing.T) {
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_DeactivateRequest{
+				DeactivateRequest: &pb.SubscribeActorEventsResponseDeactivateRequestAlpha1{
+					Id:        "30",
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		deactivateResp := resp.GetDeactivateResponse()
+		require.NotNil(t, deactivateResp)
+		assert.Equal(t, "30", deactivateResp.GetId())
+
+		calls := handler.deactivateCalls()
+		require.Len(t, calls, 1)
+		assert.Equal(t, "testActorType", calls[0].actorType)
+		assert.Equal(t, "myactor", calls[0].actorID)
+	})
+
+	t.Run("actor not found", func(t *testing.T) {
+		handler.setDeactivateErr(actorErr.ErrActorIDNotFound)
+
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_DeactivateRequest{
+				DeactivateRequest: &pb.SubscribeActorEventsResponseDeactivateRequestAlpha1{
+					Id:        "31",
+					ActorType: "testActorType",
+					ActorId:   "missing",
+				},
+			},
+		})
+
+		resp := recvWithTimeout(t, session.responses)
+		failed := resp.GetRequestFailed()
+		require.NotNil(t, failed)
+		assert.Equal(t, "31", failed.GetId())
+		assert.Equal(t, uint32(codes.NotFound), failed.GetCode())
+	})
+}
+
+func TestSubscribeActorEventsConcurrentDispatch(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	const numCalls = 50
+
+	// Block all invocations until every callback has been dispatched, proving
+	// the read loop keeps draining while handlers are in flight and that
+	// concurrent sends are serialized.
+	unblock := make(chan struct{})
+	handler := &testActorEventHandler{
+		actorTypes: []string{"testActorType"},
+		invokeFn: func(ctx context.Context, actorType, actorID, method string, payload []byte) ([]byte, actorErr.ActorErr) {
+			<-unblock
+			return payload, actorErr.Success
+		},
+	}
+
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	session := recvWithTimeout(t, srv.sessions)
+
+	for i := range numCalls {
+		session.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+			ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+				InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+					Id:        strconv.Itoa(i),
+					ActorType: "testActorType",
+					ActorId:   "myactor",
+					Method:    "Echo",
+					Data:      []byte(fmt.Sprintf(`"%d"`, i)),
+				},
+			},
+		})
+	}
+	close(unblock)
+
+	ids := make(map[string]bool, numCalls)
+	for range numCalls {
+		resp := recvWithTimeout(t, session.responses)
+		invokeResp := resp.GetInvokeResponse()
+		require.NotNil(t, invokeResp)
+		ids[invokeResp.GetId()] = true
+		// Response data is correlated with the request id.
+		assert.Equal(t, fmt.Sprintf(`"%s"`, invokeResp.GetId()), string(invokeResp.GetData()))
+	}
+	assert.Len(t, ids, numCalls)
+}
+
+func TestSubscribeActorEventsReconnect(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	handler := &testActorEventHandler{actorTypes: []string{"testActorType"}}
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+	defer stop() //nolint:errcheck
+
+	recvWithTimeout(t, srv.initialRequests)
+	session := recvWithTimeout(t, srv.sessions)
+
+	// Kill the stream server-side; the subscription must reconnect and
+	// re-send the initial registration.
+	session.kill(status.Error(codes.Unavailable, "sidecar restarting"))
+
+	initial := recvWithTimeout(t, srv.initialRequests)
+	assert.Equal(t, []string{"testActorType"}, initial.GetEntities())
+	newSession := recvWithTimeout(t, srv.sessions)
+
+	// The new stream is fully functional.
+	newSession.push(t, &pb.SubscribeActorEventsResponseAlpha1{
+		ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InvokeRequest{
+			InvokeRequest: &pb.SubscribeActorEventsResponseInvokeRequestAlpha1{
+				Id:        "1",
+				ActorType: "testActorType",
+				ActorId:   "myactor",
+				Method:    "GetUser",
+			},
+		},
+	})
+
+	resp := recvWithTimeout(t, newSession.responses)
+	require.NotNil(t, resp.GetInvokeResponse())
+	assert.Equal(t, "1", resp.GetInvokeResponse().GetId())
+}
+
+func TestSubscribeActorEventsStop(t *testing.T) {
+	srv, client := newTestActorEventsServer(t)
+
+	handler := &testActorEventHandler{actorTypes: []string{"testActorType"}}
+	stop, err := client.SubscribeActorEvents(t.Context(), handler, ActorEventSubscriptionOptions{})
+	require.NoError(t, err)
+
+	recvWithTimeout(t, srv.initialRequests)
+	recvWithTimeout(t, srv.sessions)
+
+	require.NoError(t, stop())
+	require.Error(t, stop(), "second stop must report the subscription is already closed")
+
+	// A stopped subscription must not reconnect.
+	select {
+	case <-srv.initialRequests:
+		t.Fatal("subscription reconnected after being stopped")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func Test_actorErrToStatusCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  actorErr.ActorErr
+		want codes.Code
+	}{
+		{"actor type not found", actorErr.ErrActorTypeNotFound, codes.NotFound},
+		{"actor method not found", actorErr.ErrActorMethodNoFound, codes.NotFound},
+		{"actor id not found", actorErr.ErrActorIDNotFound, codes.NotFound},
+		{"reminder func undefined", actorErr.ErrReminderFuncUndefined, codes.NotFound},
+		{"reminder params invalid", actorErr.ErrRemindersParamsInvalid, codes.InvalidArgument},
+		{"timer params invalid", actorErr.ErrTimerParamsInvalid, codes.InvalidArgument},
+		{"invoke failed", actorErr.ErrActorInvokeFailed, codes.Internal},
+		{"save state failed", actorErr.ErrSaveStateFailed, codes.Internal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, actorErrToStatusCode(tt.err))
+		})
+	}
+}
+
+func Test_anyToRawData(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, anyToRawData(nil))
+	})
+
+	t.Run("wrapped bytes", func(t *testing.T) {
+		data, err := anypb.New(wrapperspb.Bytes([]byte(`{"key":"value"}`)))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`{"key":"value"}`), anyToRawData(data))
+	})
+
+	t.Run("typed message", func(t *testing.T) {
+		data, err := anypb.New(wrapperspb.String("hello"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`"hello"`), anyToRawData(data))
+	})
+
+	t.Run("unknown type falls back to raw value", func(t *testing.T) {
+		data := &anypb.Any{
+			TypeUrl: "type.googleapis.com/unknown.Type",
+			Value:   []byte("raw"),
+		}
+		assert.Equal(t, []byte("raw"), anyToRawData(data))
+	})
+}
+
+func Test_reentrancyIDFromContext(t *testing.T) {
+	t.Run("no metadata", func(t *testing.T) {
+		_, ok := reentrancyIDFromContext(t.Context())
+		assert.False(t, ok)
+	})
+
+	t.Run("metadata without reentrancy id", func(t *testing.T) {
+		ctx := withActorCallbackMetadata(t.Context(), map[string]string{"content-type": "application/json"})
+		_, ok := reentrancyIDFromContext(ctx)
+		assert.False(t, ok)
+	})
+
+	t.Run("reentrancy id", func(t *testing.T) {
+		ctx := withActorCallbackMetadata(t.Context(), map[string]string{"Dapr-Reentrancy-Id": "id-1"})
+		id, ok := reentrancyIDFromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "id-1", id)
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		ctx := withActorCallbackMetadata(t.Context(), map[string]string{"dapr-reentrancy-id": "id-2"})
+		id, ok := reentrancyIDFromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "id-2", id)
+	})
+}
+
+// newTestActorEventsServer starts a dedicated in-memory Dapr server
+// implementing SubscribeActorEventsAlpha1 and returns it along with a client
+// connected to it.
+func newTestActorEventsServer(t *testing.T) (*fakeActorEventsServer, Client) {
+	t.Helper()
+
+	srv := &fakeActorEventsServer{
+		initialRequests: make(chan *pb.SubscribeActorEventsRequestInitialAlpha1, 16),
+		sessions:        make(chan *actorEventsTestSession, 16),
+	}
+
+	s := grpc.NewServer()
+	pb.RegisterDaprServer(s, srv)
+
+	l := bufconn.Listen(testBufSize)
+	go func() {
+		_ = s.Serve(l)
+	}()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return l.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = conn.Close()
+		s.Stop()
+		_ = l.Close()
+	})
+
+	return srv, NewClientWithConnection(conn)
+}
+
+type fakeActorEventsServer struct {
+	pb.UnimplementedDaprServer
+
+	initialRequests chan *pb.SubscribeActorEventsRequestInitialAlpha1
+	sessions        chan *actorEventsTestSession
+}
+
+// actorEventsTestSession represents one established actor events stream. The
+// test pushes callbacks to the app with push and reads the app's responses
+// from responses. kill makes the server side fail the stream.
+type actorEventsTestSession struct {
+	stream    pb.Dapr_SubscribeActorEventsAlpha1Server
+	responses chan *pb.SubscribeActorEventsRequestAlpha1
+	killCh    chan error
+	recvDone  chan struct{}
+}
+
+func (s *fakeActorEventsServer) SubscribeActorEventsAlpha1(stream pb.Dapr_SubscribeActorEventsAlpha1Server) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	initial := first.GetInitialRequest()
+	if initial == nil {
+		return status.Error(codes.InvalidArgument, "first message must be the initial request")
+	}
+	s.initialRequests <- initial
+
+	if err := stream.Send(&pb.SubscribeActorEventsResponseAlpha1{
+		ResponseType: &pb.SubscribeActorEventsResponseAlpha1_InitialResponse{
+			InitialResponse: &pb.SubscribeActorEventsResponseInitialAlpha1{},
+		},
+	}); err != nil {
+		return err
+	}
+
+	session := &actorEventsTestSession{
+		stream:    stream,
+		responses: make(chan *pb.SubscribeActorEventsRequestAlpha1, 64),
+		killCh:    make(chan error, 1),
+		recvDone:  make(chan struct{}),
+	}
+	s.sessions <- session
+
+	go func() {
+		defer close(session.recvDone)
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				return
+			}
+			session.responses <- msg
+		}
+	}()
+
+	select {
+	case err := <-session.killCh:
+		return err
+	case <-session.recvDone:
+		return nil
+	case <-stream.Context().Done():
+		return nil
+	}
+}
+
+func (s *actorEventsTestSession) push(t *testing.T, msg *pb.SubscribeActorEventsResponseAlpha1) {
+	t.Helper()
+	require.NoError(t, s.stream.Send(msg))
+}
+
+func (s *actorEventsTestSession) kill(err error) {
+	s.killCh <- err
+}
+
+func recvWithTimeout[T any](t *testing.T, ch <-chan T) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(testActorEventsTimeout):
+		t.Fatal("timed out waiting for message")
+		panic("unreachable")
+	}
+}
+
+type invokeCall struct {
+	ctx       context.Context
+	actorType string
+	actorID   string
+	method    string
+	payload   []byte
+}
+
+type reminderCall struct {
+	actorType string
+	actorID   string
+	name      string
+	params    []byte
+}
+
+type deactivateCall struct {
+	actorType string
+	actorID   string
+}
+
+// testActorEventHandler is a configurable ActorEventHandler recording every
+// dispatched callback.
+type testActorEventHandler struct {
+	actorTypes []string
+
+	invokeFn func(ctx context.Context, actorType, actorID, method string, payload []byte) ([]byte, actorErr.ActorErr)
+
+	lock          sync.Mutex
+	invokes       []invokeCall
+	reminders     []reminderCall
+	timers        []reminderCall
+	deactivations []deactivateCall
+	invokeErr     actorErr.ActorErr
+	reminderErr   actorErr.ActorErr
+	timerErr      actorErr.ActorErr
+	deactivateErr actorErr.ActorErr
+}
+
+func (h *testActorEventHandler) RegisteredActorTypes() []string {
+	return h.actorTypes
+}
+
+func (h *testActorEventHandler) InvokeActorMethod(ctx context.Context, actorType, actorID, method string, payload []byte) ([]byte, actorErr.ActorErr) {
+	h.lock.Lock()
+	h.invokes = append(h.invokes, invokeCall{ctx: ctx, actorType: actorType, actorID: actorID, method: method, payload: payload})
+	invokeErr := h.invokeErr
+	invokeFn := h.invokeFn
+	h.lock.Unlock()
+
+	if invokeFn != nil {
+		return invokeFn(ctx, actorType, actorID, method, payload)
+	}
+	if invokeErr != actorErr.Success {
+		return nil, invokeErr
+	}
+	return payload, actorErr.Success
+}
+
+func (h *testActorEventHandler) InvokeReminder(ctx context.Context, actorType, actorID, reminderName string, params []byte) actorErr.ActorErr {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.reminders = append(h.reminders, reminderCall{actorType: actorType, actorID: actorID, name: reminderName, params: params})
+	return h.reminderErr
+}
+
+func (h *testActorEventHandler) InvokeTimer(ctx context.Context, actorType, actorID, timerName string, params []byte) actorErr.ActorErr {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.timers = append(h.timers, reminderCall{actorType: actorType, actorID: actorID, name: timerName, params: params})
+	return h.timerErr
+}
+
+func (h *testActorEventHandler) Deactivate(ctx context.Context, actorType, actorID string) actorErr.ActorErr {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.deactivations = append(h.deactivations, deactivateCall{actorType: actorType, actorID: actorID})
+	return h.deactivateErr
+}
+
+func (h *testActorEventHandler) invokeCalls() []invokeCall {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	return append([]invokeCall(nil), h.invokes...)
+}
+
+func (h *testActorEventHandler) reminderCalls() []reminderCall {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	return append([]reminderCall(nil), h.reminders...)
+}
+
+func (h *testActorEventHandler) timerCalls() []reminderCall {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	return append([]reminderCall(nil), h.timers...)
+}
+
+func (h *testActorEventHandler) deactivateCalls() []deactivateCall {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	return append([]deactivateCall(nil), h.deactivations...)
+}
+
+func (h *testActorEventHandler) setInvokeErr(err actorErr.ActorErr) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.invokeErr = err
+}
+
+func (h *testActorEventHandler) setReminderErr(err actorErr.ActorErr) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.reminderErr = err
+}
+
+func (h *testActorEventHandler) setDeactivateErr(err actorErr.ActorErr) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.deactivateErr = err
+}

--- a/client/client.go
+++ b/client/client.go
@@ -173,6 +173,13 @@ type Client interface {
 	// The returned cancel function must be called after  finishing with subscribing.
 	SubscribeWithHandler(ctx context.Context, opts SubscriptionOptions, handler SubscriptionHandleFunction) (func() error, error)
 
+	// SubscribeActorEvents registers the handler's actor types with the Dapr
+	// sidecar and hosts them over a bidirectional event stream, with no need
+	// to expose a server port for actor callbacks. The returned stop function
+	// must be called to stop hosting the actor types.
+	// This API is currently in Alpha.
+	SubscribeActorEvents(ctx context.Context, handler ActorEventHandler, opts ActorEventSubscriptionOptions) (func() error, error)
+
 	// DeleteBulkState deletes content for multiple keys from store.
 	DeleteBulkState(ctx context.Context, storeName string, keys []string, meta map[string]string) error
 

--- a/examples/actor-grpc/README.md
+++ b/examples/actor-grpc/README.md
@@ -1,0 +1,130 @@
+# Dapr gRPC Actor Example with go-sdk
+
+This example hosts actors over the app-initiated actor event stream
+(`SubscribeActorEventsAlpha1`): the application dials the Dapr sidecar's gRPC
+port and receives all actor callbacks (method invocations, reminders, timers,
+deactivations) over a single bidirectional stream, instead of exposing HTTP
+actor endpoints.
+
+> This feature is in **Alpha** and requires the Dapr sidecar to run with
+> `--app-protocol grpc`.
+
+The actor implementation is identical to the [HTTP actor example](../actor):
+only the hosting changes, from `service/http` to
+`client.SubscribeActorEvents`.
+
+## Step
+
+### Prepare
+
+- Dapr installed
+
+### Run Actor Server
+
+<!-- STEP
+name: Run Actor server
+output_match_mode: substring
+expected_stdout_lines:
+  - 'actor event subscription started'
+  - 'call get user req =  &{abc 123}'
+  - 'get req =  laurence'
+  - 'get post request =  laurence'
+  - 'get req =  hello'
+  - 'get req =  hello'
+  - 'receive reminder =  testReminderName  state =  "hello"'
+  - 'receive reminder =  testReminderName  state =  "hello"'
+background: true
+timeout_seconds: 60
+-->
+
+```bash
+dapr run --app-id actor-grpc-serving \
+         --app-protocol grpc \
+         --app-port 50051 \
+         --log-level debug \
+         --resources-path ./config \
+         go run ./serving/main.go
+```
+
+<!-- END_STEP -->
+
+### Run Actor Client
+
+<!-- STEP
+name: Run Actor Client
+output_match_mode: substring
+expected_stdout_lines:
+  - 'get user result =  &{abc 123}'
+  - 'get invoke result =  laurence'
+  - 'get post result =  laurence'
+  - 'get result =  get result'
+  - 'start timer'
+  - 'stop timer'
+  - 'start reminder'
+  - 'stop reminder'
+  - 'get user = {Name: Age:1}'
+  - 'get user = {Name: Age:2}'
+
+timeout_seconds: 60
+-->
+
+```bash
+dapr run --app-id actor-grpc-client \
+         --log-level debug \
+         --resources-path ./config \
+         go run ./client/main.go
+```
+
+<!-- END_STEP -->
+
+### Cleanup
+
+<!-- STEP
+name: Cleanup actor server
+expected_return_code:
+-->
+
+```bash
+dapr stop --app-id actor-grpc-serving
+(lsof -i:50051 | grep main) | awk '{print $2}' | xargs kill
+```
+
+<!-- END_STEP -->
+
+## Result
+- client side
+```
+dapr client initializing for: 127.0.0.1:55776
+get user result =  &{abc 123}
+get invoke result =  laurence
+get post result =  laurence
+get result =  get result
+start timer
+stop timer
+start reminder
+stop reminder
+get user = {Name: Age:1}
+get user = {Name: Age:2}
+✅  Exited App successfully
+```
+
+- server side
+
+```
+actor event subscription started
+call get user req =  &{abc 123}
+get req =  laurence
+get post request =  laurence
+get req =  hello
+get req =  hello
+receive reminder =  testReminderName  state =  "hello"
+receive reminder =  testReminderName  state =  "hello"
+```
+
+## Notes
+
+- The gRPC service on `:50051` only backs the sidecar's app channel (which
+  must be gRPC for the stream to be accepted); actor callbacks never reach
+  it — they are all delivered over the actor event stream.
+- The stream automatically reconnects and re-registers the actor types if the
+  sidecar restarts or the stream drops.

--- a/examples/actor-grpc/api/actor.go
+++ b/examples/actor-grpc/api/actor.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import "context"
+
+type ClientStub struct {
+	GetUser         func(context.Context, *User) (*User, error)
+	Invoke          func(context.Context, string) (string, error)
+	Get             func(context.Context) (string, error)
+	Post            func(context.Context, string) error
+	StartTimer      func(context.Context, *TimerRequest) error
+	StopTimer       func(context.Context, *TimerRequest) error
+	StartReminder   func(context.Context, *ReminderRequest) error
+	StopReminder    func(context.Context, *ReminderRequest) error
+	IncrementAndGet func(ctx context.Context, stateKey string) (*User, error)
+}
+
+func (a *ClientStub) Type() string {
+	return "testActorGrpcType"
+}
+
+func (a *ClientStub) ID() string {
+	return "ActorImplID123456"
+}
+
+type User struct {
+	Name string `json:"name"`
+	Age  uint32 `json:"age"`
+}
+
+type TimerRequest struct {
+	TimerName string `json:"timer_name"`
+	CallBack  string `json:"call_back"`
+	Duration  string `json:"duration"`
+	Period    string `json:"period"`
+	Data      string `json:"data"`
+}
+
+type ReminderRequest struct {
+	ReminderName string `json:"reminder_name"`
+	Duration     string `json:"duration"`
+	Period       string `json:"period"`
+	Data         string `json:"data"`
+}

--- a/examples/actor-grpc/client/main.go
+++ b/examples/actor-grpc/client/main.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	dapr "github.com/dapr/go-sdk/client"
+	"github.com/dapr/go-sdk/examples/actor-grpc/api"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// create the client
+	client, err := dapr.NewClient()
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// implement actor client stub
+	myActor := new(api.ClientStub)
+	client.ImplActorClientStub(myActor)
+
+	// Invoke user defined method GetUser with user defined param api.User and response
+	// using default serializer type json
+	user, err := myActor.GetUser(ctx, &api.User{
+		Name: "abc",
+		Age:  123,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("get user result = ", user)
+
+	// Invoke user defined method Invoke
+	rsp, err := myActor.Invoke(ctx, "laurence")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("get invoke result = ", rsp)
+
+	// Invoke user defined method Post with empty response
+	err = myActor.Post(ctx, "laurence")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("get post result = ", rsp)
+
+	// Invoke user defined method Get with empty request param
+	rsp, err = myActor.Get(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("get result = ", rsp)
+
+	// Invoke user defined method StartTimer, and server side actor start actor timer with given params.
+	err = myActor.StartTimer(ctx, &api.TimerRequest{
+		TimerName: "testTimerName",
+		CallBack:  "Invoke",
+		Period:    "5s",
+		Duration:  "5s",
+		Data:      `"hello"`,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("start timer")
+	<-time.After(time.Second * 10) // timer call for twice
+
+	// Invoke user defined method StopTimer, and server side actor stop actor timer with given params.
+	err = myActor.StopTimer(ctx, &api.TimerRequest{
+		TimerName: "testTimerName",
+		CallBack:  "Invoke",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("stop timer")
+
+	// Invoke user defined method StartReminder, and server side actor start actor reminder with given params.
+	err = myActor.StartReminder(ctx, &api.ReminderRequest{
+		ReminderName: "testReminderName",
+		Period:       "5s",
+		Duration:     "5s",
+		Data:         `"hello"`,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("start reminder")
+	<-time.After(time.Second * 10) // reminder call for twice
+
+	// Invoke user defined method StopReminder, and server side actor stop actor reminder with given params.
+	err = myActor.StopReminder(ctx, &api.ReminderRequest{
+		ReminderName: "testReminderName",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("stop reminder")
+
+	// Make state key unique to allow multiple runs without side effects
+	testStateKey := fmt.Sprintf("testStateKey-%s", uuid.New().String())
+	for i := 0; i < 2; i++ {
+		// Invoke user defined method IncrementAndGet, and server side actor increase the state named testStateKey and return.
+		usr, err := myActor.IncrementAndGet(ctx, testStateKey)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("get user = %+v\n", *usr)
+		time.Sleep(time.Second)
+	}
+}

--- a/examples/actor-grpc/config/redis.yaml
+++ b/examples/actor-grpc/config/redis.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: actorStateStore
+    value: "true"

--- a/examples/actor-grpc/serving/main.go
+++ b/examples/actor-grpc/serving/main.go
@@ -184,11 +184,9 @@ func main() {
 }
 
 func subscribeWithRetry(ctx context.Context, client dapr.Client, rt *runtime.ActorRunTimeContext) (func() error, error) {
-	var (
-		stop func() error
-		err  error
-	)
+	var err error
 	for i := 0; i < 30; i++ {
+		var stop func() error
 		stop, err = client.SubscribeActorEvents(ctx, rt, dapr.ActorEventSubscriptionOptions{
 			ActorIdleTimeout: time.Hour,
 		})
@@ -196,7 +194,12 @@ func subscribeWithRetry(ctx context.Context, client dapr.Client, rt *runtime.Act
 			return stop, nil
 		}
 		logger.Printf("actor event subscription not ready, retrying: %v", err)
-		time.Sleep(time.Second)
+		// Stop retrying promptly if the caller cancels (e.g. shutdown).
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Second):
+		}
 	}
 	return nil, err
 }

--- a/examples/actor-grpc/serving/main.go
+++ b/examples/actor-grpc/serving/main.go
@@ -33,13 +33,14 @@ import (
 
 var logger = log.New(os.Stdout, "", log.LstdFlags)
 
-func testActorFactory() actor.ServerContext {
-	client, err := dapr.NewClient()
-	if err != nil {
-		panic(err)
-	}
-	return &TestActor{
-		daprClient: client,
+// testActorFactory returns a factory that shares a single Dapr client across
+// all actor instances instead of opening (and leaking) a new connection per
+// activation.
+func testActorFactory(client dapr.Client) actor.FactoryContext {
+	return func() actor.ServerContext {
+		return &TestActor{
+			daprClient: client,
+		}
 	}
 }
 
@@ -152,6 +153,7 @@ func main() {
 			logger.Fatalf("error listening: %v", err)
 		}
 	}()
+	defer s.GracefulStop() //nolint:errcheck
 
 	client, err := dapr.NewClient()
 	if err != nil {
@@ -160,9 +162,9 @@ func main() {
 	defer client.Close()
 
 	// Register the hosted actor types on the actor runtime, exactly as when
-	// hosting actors over HTTP.
+	// hosting actors over HTTP. The actors share the client created above.
 	rt := runtime.GetActorRuntimeInstanceContext()
-	rt.RegisterActorFactory(testActorFactory)
+	rt.RegisterActorFactory(testActorFactory(client))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -184,6 +186,9 @@ func main() {
 }
 
 func subscribeWithRetry(ctx context.Context, client dapr.Client, rt *runtime.ActorRunTimeContext) (func() error, error) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
 	var err error
 	for i := 0; i < 30; i++ {
 		var stop func() error
@@ -198,7 +203,7 @@ func subscribeWithRetry(ctx context.Context, client dapr.Client, rt *runtime.Act
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(time.Second):
+		case <-ticker.C:
 		}
 	}
 	return nil, err

--- a/examples/actor-grpc/serving/main.go
+++ b/examples/actor-grpc/serving/main.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/dapr/go-sdk/actor"
+	"github.com/dapr/go-sdk/actor/runtime"
+	dapr "github.com/dapr/go-sdk/client"
+	"github.com/dapr/go-sdk/examples/actor-grpc/api"
+	"github.com/dapr/kit/ptr"
+
+	daprd "github.com/dapr/go-sdk/service/grpc"
+)
+
+var logger = log.New(os.Stdout, "", log.LstdFlags)
+
+func testActorFactory() actor.ServerContext {
+	client, err := dapr.NewClient()
+	if err != nil {
+		panic(err)
+	}
+	return &TestActor{
+		daprClient: client,
+	}
+}
+
+type TestActor struct {
+	actor.ServerImplBaseCtx
+	daprClient dapr.Client
+}
+
+func (t *TestActor) Type() string {
+	return "testActorGrpcType"
+}
+
+// user defined functions
+func (t *TestActor) StopTimer(ctx context.Context, req *api.TimerRequest) error {
+	return t.daprClient.UnregisterActorTimer(ctx, &dapr.UnregisterActorTimerRequest{
+		ActorType: t.Type(),
+		ActorID:   t.ID(),
+		Name:      req.TimerName,
+	})
+}
+
+func (t *TestActor) StartTimer(ctx context.Context, req *api.TimerRequest) error {
+	return t.daprClient.RegisterActorTimer(ctx, &dapr.RegisterActorTimerRequest{
+		ActorType: t.Type(),
+		ActorID:   t.ID(),
+		Name:      req.TimerName,
+		DueTime:   req.Duration,
+		Period:    req.Period,
+		Data:      []byte(req.Data),
+		CallBack:  req.CallBack,
+	})
+}
+
+func (t *TestActor) StartReminder(ctx context.Context, req *api.ReminderRequest) error {
+	return t.daprClient.RegisterActorReminder(ctx, &dapr.RegisterActorReminderRequest{
+		ActorType: t.Type(),
+		ActorID:   t.ID(),
+		Name:      req.ReminderName,
+		DueTime:   req.Duration,
+		Period:    req.Period,
+		Data:      []byte(req.Data),
+		FailurePolicy: &dapr.JobFailurePolicyConstant{
+			MaxRetries: nil,
+			Interval:   ptr.Of(time.Second * 1),
+		},
+	})
+}
+
+func (t *TestActor) StopReminder(ctx context.Context, req *api.ReminderRequest) error {
+	return t.daprClient.UnregisterActorReminder(ctx, &dapr.UnregisterActorReminderRequest{
+		ActorType: t.Type(),
+		ActorID:   t.ID(),
+		Name:      req.ReminderName,
+	})
+}
+
+func (t *TestActor) Invoke(ctx context.Context, req string) (string, error) {
+	fmt.Println("get req = ", req)
+	return req, nil
+}
+
+func (t *TestActor) GetUser(ctx context.Context, user *api.User) (*api.User, error) {
+	fmt.Println("call get user req = ", user)
+	return user, nil
+}
+
+func (t *TestActor) Get(context.Context) (string, error) {
+	return "get result", nil
+}
+
+func (t *TestActor) Post(ctx context.Context, req string) error {
+	fmt.Println("get post request = ", req)
+	return nil
+}
+
+func (t *TestActor) IncrementAndGet(ctx context.Context, stateKey string) (*api.User, error) {
+	stateData := api.User{}
+	if exist, err := t.GetStateManager().Contains(ctx, stateKey); err != nil {
+		fmt.Println("state manager call contains with key " + stateKey + "err = " + err.Error())
+		return &stateData, err
+	} else if exist {
+		if err := t.GetStateManager().Get(ctx, stateKey, &stateData); err != nil {
+			fmt.Println("state manager call get with key " + stateKey + "err = " + err.Error())
+			return &stateData, err
+		}
+	}
+	stateData.Age++
+	if err := t.GetStateManager().Set(ctx, stateKey, stateData); err != nil {
+		fmt.Printf("state manager set get with key %s and state data = %+v, error = %s", stateKey, stateData, err.Error())
+		return &stateData, err
+	}
+	return &stateData, nil
+}
+
+func (t *TestActor) ReminderCall(reminderName string, state []byte, dueTime string, period string) {
+	fmt.Println("receive reminder = ", reminderName, " state = ", string(state))
+}
+
+func main() {
+	// The Dapr sidecar accepts the actor event stream only when its app
+	// channel is gRPC (--app-protocol grpc), so serve the gRPC app callback
+	// service. Actor callbacks are NOT delivered to this server: they all
+	// arrive over the actor event stream below.
+	s, err := daprd.NewService(":50051")
+	if err != nil {
+		logger.Fatalf("error creating gRPC service: %v", err)
+	}
+	go func() {
+		if err := s.Start(); err != nil {
+			logger.Fatalf("error listening: %v", err)
+		}
+	}()
+
+	client, err := dapr.NewClient()
+	if err != nil {
+		logger.Fatalf("error creating Dapr client: %v", err)
+	}
+	defer client.Close()
+
+	// Register the hosted actor types on the actor runtime, exactly as when
+	// hosting actors over HTTP.
+	rt := runtime.GetActorRuntimeInstanceContext()
+	rt.RegisterActorFactory(testActorFactory)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Host the registered actor types over the actor event stream. The
+	// sidecar may still be initializing its app channel, so retry for a
+	// short while before giving up.
+	stop, err := subscribeWithRetry(ctx, client, rt)
+	if err != nil {
+		logger.Fatalf("error subscribing to actor events: %v", err)
+	}
+	defer stop() //nolint:errcheck
+
+	fmt.Println("actor event subscription started")
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	<-sigCh
+}
+
+func subscribeWithRetry(ctx context.Context, client dapr.Client, rt *runtime.ActorRunTimeContext) (func() error, error) {
+	var (
+		stop func() error
+		err  error
+	)
+	for i := 0; i < 30; i++ {
+		stop, err = client.SubscribeActorEvents(ctx, rt, dapr.ActorEventSubscriptionOptions{
+			ActorIdleTimeout: time.Hour,
+		})
+		if err == nil {
+			return stop, nil
+		}
+		logger.Printf("actor event subscription not ready, retrying: %v", err)
+		time.Sleep(time.Second)
+	}
+	return nil, err
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -6,9 +6,9 @@ replace github.com/dapr/go-sdk => ../
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/dapr/durabletask-go v0.12.0
+	github.com/dapr/durabletask-go v0.12.1
 	github.com/dapr/go-sdk v0.0.0-00010101000000-000000000000
-	github.com/dapr/kit v0.18.0
+	github.com/dapr/kit v0.18.1
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
 	google.golang.org/grpc v1.79.3

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -8,10 +8,10 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dapr/dapr v1.18.0-rc.4 h1:h5WG5uH8jduRAIt2Rn8vyi/eUUJjmzDzyAx3u/aAxDk=
 github.com/dapr/dapr v1.18.0-rc.4/go.mod h1:etCWO1UxMp8IvPJcZ+EyroJ8R3q2MSaW9m61i2qbx5w=
-github.com/dapr/durabletask-go v0.12.0 h1:R44GG/DYmonLMh6RVDkG7QlbTGkiGi8sCbuB/4WhWwE=
-github.com/dapr/durabletask-go v0.12.0/go.mod h1:jeY+1a3CdvSjVebLijYuXl2vbI+bpdssIeu5Crw0OoY=
-github.com/dapr/kit v0.18.0 h1:AF1eI7C8sLx9n0Lg3c+etPkHvUCVM8k769aABKSlyF4=
-github.com/dapr/kit v0.18.0/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
+github.com/dapr/durabletask-go v0.12.1 h1:CIqG2HJGnU7kRtHICuRSSSO9RdHax99HdvHEaxRGE04=
+github.com/dapr/durabletask-go v0.12.1/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
+github.com/dapr/kit v0.18.1 h1:tC+og80ksS4obx3aExdMpIVMxspz8fdjH3t8J5e0QUw=
+github.com/dapr/kit v0.18.1/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
# Description

Adds support for **hosting Dapr actors over gRPC** via the app-initiated `SubscribeActorEventsAlpha1` stream (dapr/dapr [#9812](https://github.com/dapr/dapr/pull/9812)).

Today an app that hosts actors must expose HTTP callback endpoints that the sidecar calls into (`PUT /actors/{type}/{id}/method/{method}`, `GET /dapr/config`, `GET /healthz`, …). This PR adds an alternative where **the app is the gRPC client**: it dials the sidecar's existing gRPC port, opens one bidirectional stream, registers its actor types, and receives all actor callbacks (method invoke, reminder, timer, deactivate) over that stream, no inbound server port for actor callbacks, no `/healthz`, no `/dapr/config`. The open stream itself is the liveness signal and the initial message replaces the HTTP config endpoint.

This is **additive and Alpha**. HTTP actor hosting is unchanged, and the same actor implementations run over either transport, only the hosting call differs.

## How it works

The implementation mirrors the existing streaming PubSub client (`client/subscribe.go`): handshake → ack → recv loop → correlated responses, with serialized sends and automatic reconnect.

```go
client, _ := dapr.NewClient()

// gRPC app channel must exist for the sidecar to accept the stream,
// but actor callbacks never reach it, they arrive over the stream.
svc, _ := daprd.NewService(":50051")
go svc.Start()

// Register actor types exactly as for HTTP hosting.
rt := runtime.GetActorRuntimeInstanceContext()
rt.RegisterActorFactory(testActorFactory)

// Host them over the actor event stream (Alpha). Reconnects automatically.
stop, _ := client.SubscribeActorEvents(ctx, rt, dapr.ActorEventSubscriptionOptions{
    ActorIdleTimeout: time.Hour,
})
defer stop()
```

## Issue reference

Closes https://github.com/dapr/go-sdk/issues/827
