### PR TITLE
fix(examples/jobs): wait on job triggers instead of wall-clock time

### DIFF
--- a/examples/jobs/README.md
+++ b/examples/jobs/README.md
@@ -24,7 +24,7 @@ expected_stdout_lines:
   - 'deletejob - success'
 
 background: true
-sleep: 30
+sleep: 45
 
 -->
 

--- a/examples/jobs/main.go
+++ b/examples/jobs/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/protobuf/types/known/anypb"
@@ -17,6 +18,14 @@ import (
 )
 
 var logger = log.New(os.Stdout, "", log.LstdFlags)
+
+// expectedJobRuns is the number of triggers this example waits for before it
+// inspects and deletes the job.
+const expectedJobRuns = 3
+
+// jobRuns is signalled once per received trigger, so the example can wait on
+// the triggers themselves instead of on wall-clock time.
+var jobRuns = make(chan struct{}, expectedJobRuns)
 
 func main() {
 	server, err := daprs.NewService(":50070")
@@ -60,7 +69,10 @@ func main() {
 		}),
 		daprc.WithJobConstantFailurePolicy(),
 		daprc.WithJobConstantFailurePolicyMaxRetries(4),
-		daprc.WithJobConstantFailurePolicyInterval(time.Second*30),
+		// The retry interval has to stay well below the lifetime of this
+		// example, otherwise a single failed trigger can never be retried
+		// before the program exits.
+		daprc.WithJobConstantFailurePolicyInterval(time.Second),
 	)
 
 	// create the client
@@ -77,7 +89,12 @@ func main() {
 
 	fmt.Println("schedulejob - success")
 
-	time.Sleep(3 * time.Second)
+	// Wait for the job to actually fire. Sleeping for a fixed duration instead
+	// makes the run depend on how long the sidecar took to start, and on
+	// whether every trigger succeeded on its first attempt.
+	if err = waitForJobRuns(expectedJobRuns, 20*time.Second); err != nil {
+		panic(err)
+	}
 
 	resp, err := client.GetJobAlpha1(ctx, "prod-db-backup")
 	if err != nil {
@@ -97,14 +114,35 @@ func main() {
 	}
 }
 
-var jobCount = 0
+// waitForJobRuns blocks until the handler has reported count triggers, or
+// until timeout elapses.
+func waitForJobRuns(count int, timeout time.Duration) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	for i := 0; i < count; i++ {
+		select {
+		case <-jobRuns:
+		case <-deadline.C:
+			return fmt.Errorf("timed out after %s waiting for %d job triggers, got %d", timeout, count, i)
+		}
+	}
+	return nil
+}
+
+var jobCount atomic.Int64
 
 func prodDBBackupHandler(ctx context.Context, job *common.JobEvent) error {
 	var jobPayload api.DBBackup
 	if err := json.Unmarshal(job.Data, &jobPayload); err != nil {
 		return fmt.Errorf("failed to unmarshal payload: %v", err)
 	}
-	fmt.Printf("job %d received:\n type: %v \n payload: %v\n", jobCount, job.JobType, jobPayload)
-	jobCount++
+	fmt.Printf("job %d received:\n type: %v \n payload: %v\n", jobCount.Add(1)-1, job.JobType, jobPayload)
+
+	// Never block the handler: the sidecar treats a slow response as a failure.
+	select {
+	case jobRuns <- struct{}{}:
+	default:
+	}
 	return nil
 }


### PR DESCRIPTION
## Description

Fixes the flaky `validate-example (jobs)` job reported in #805.

The example sleeps for a fixed 3 seconds after scheduling the job and then relies on three triggers having already been printed. Two things make that unreliable:

1. **No margin for a retry.** The job is created with `WithJobConstantFailurePolicyInterval(time.Second*30)`. In the [linked failing run](https://github.com/dapr/go-sdk/actions/runs/22362513824/job/64719691972?pr=804) the first trigger came back `status code returned: 14` (`Unavailable`), so the next attempt was scheduled 30 seconds later, long after `main` had already deleted the job and exited. The `job 0/1/2 received` lines never appeared:

   ```
   ERROR expected lines not found:
       job 0 received
       payload: {db-backup {my-prod-db /backup-dir}}
       ...
   ```

2. **No margin for a slow sidecar.** That run logged `dapr initialized. Status: Running. Init Elapsed 20044ms`, and the whole step is capped at `sleep: 30`. The 10 second intermission plus 3 second sleep leaves the triggers almost no room inside the window.

Because `getjob` is only ordered after the trigger output by that sleep, `match_order: sequential` is also only satisfied by chance today.

## Changes

- Wait on the triggers themselves (buffered channel signalled by the handler, 20s timeout) instead of `time.Sleep(3 * time.Second)`. The example continues as soon as the job has fired the expected number of times, and the trigger output is now guaranteed to precede `getjob`.
- Lower the constant failure policy retry interval to 1s so a transient failure can be retried inside the lifetime of the example rather than 30 seconds after it exits.
- Raise the README background step from `sleep: 30` to `sleep: 45` to absorb variable sidecar start-up time.
- Make the trigger counter an `atomic.Int64`; it is written from the handler goroutine.
- The handler signals with a non-blocking send so it never delays its response to the sidecar.

Expected stdout in the README is unchanged.

## Issue reference

Closes #805

## Checklist

- [x] Code compiles correctly (`go build ./jobs/...`, `go vet ./jobs/...`, `gofmt` clean)
- [x] Extended the documentation (README timing note only; expected output unchanged)