### PR TITLE
Add missing SetWithTTL method to MockStateManagerContext

### DIFF
--- a/actor/mock/mock_server.go
+++ b/actor/mock/mock_server.go
@@ -7,6 +7,7 @@ package mock
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	actor "github.com/dapr/go-sdk/actor"
 	gomock "go.uber.org/mock/gomock"
@@ -555,4 +556,18 @@ func (m *MockStateManagerContext) Set(ctx context.Context, stateName string, val
 func (mr *MockStateManagerContextMockRecorder) Set(ctx, stateName, value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockStateManagerContext)(nil).Set), ctx, stateName, value)
+}
+
+// SetWithTTL mocks base method.
+func (m *MockStateManagerContext) SetWithTTL(ctx context.Context, stateName string, value any, ttl time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetWithTTL", ctx, stateName, value, ttl)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetWithTTL indicates an expected call of SetWithTTL.
+func (mr *MockStateManagerContextMockRecorder) SetWithTTL(ctx, stateName, value, ttl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWithTTL", reflect.TypeOf((*MockStateManagerContext)(nil).SetWithTTL), ctx, stateName, value, ttl)
 }

--- a/actor/mock/mock_server_test.go
+++ b/actor/mock/mock_server_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/dapr/go-sdk/actor"
+)
+
+// Ensure MockStateManagerContext stays in sync with the actor.StateManagerContext
+// interface it mocks.
+var _ actor.StateManagerContext = (*MockStateManagerContext)(nil)
+
+func TestMockStateManagerContextSetWithTTL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStateManager := NewMockStateManagerContext(ctrl)
+
+	mockStateManager.EXPECT().SetWithTTL(gomock.Any(), "stateName", "value", time.Second).Return(nil)
+
+	err := mockStateManager.SetWithTTL(context.Background(), "stateName", "value", time.Second)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Motivation:
Issue #548 asks for actor TTL support. Actor state TTL is already
implemented (SetWithTTL on actor.StateManagerContext, wired through to
Dapr's ActorStateOperation.TTLInSeconds), and reminder/timer TTL has
existed since 2021. However, actor/mock/mock_server.go — a MockGen
generated mock of the interfaces in actor/actor.go — was never
regenerated after SetWithTTL was added to StateManagerContext. As a
result MockStateManagerContext silently did not implement
actor.StateManagerContext, defeating the purpose of the mock for any
test that needs to stub the full interface (e.g. to unit test actor
code that calls SetWithTTL).

No existing code in the repo currently assigns a *MockStateManagerContext
to an actor.StateManagerContext-typed variable, so this did not break
any existing build or test. The fix only restores the mock's fidelity
to its source interface; it does not change any runtime behavior.

Approach:
- Add the missing SetWithTTL method (and its recorder) to
  MockStateManagerContext in actor/mock/mock_server.go, matching the
  exact style of the other generated methods in that file.
- Add actor/mock/mock_server_test.go with a compile-time assertion
  (var _ actor.StateManagerContext = (*MockStateManagerContext)(nil))
  so a future interface change that isn't reflected in the mock fails
  to build instead of failing silently, plus a small gomock-based test
  exercising the new method.

Validation:
- go build ./...  (passes)
- go test ./actor/...  (passes, including the new
  TestMockStateManagerContextSetWithTTL)
- gofmt -l on both changed files reports no diffs

Fixes #548

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>